### PR TITLE
Feature/logging

### DIFF
--- a/packages/cloudvision-connector/src/constants.ts
+++ b/packages/cloudvision-connector/src/constants.ts
@@ -24,6 +24,10 @@ import {
   WsCommand,
 } from '../types/params';
 
+export const ERROR = 'ERROR';
+export const INFO = 'INFO';
+export const WARN = 'WARN';
+
 export const EOF = 'EOF';
 /**
  * Status code for EOF (End Of File).

--- a/packages/cloudvision-connector/src/index.ts
+++ b/packages/cloudvision-connector/src/index.ts
@@ -193,7 +193,7 @@ class Connector extends WRPC {
       if (status && status.code === ACTIVE_CODE) {
         this.getWithOptions(query, callback, sanitizedOptions);
       } else {
-        subscribeNotifCallback(err, result, status, token);
+        subscribeNotifCallback(err, result, status, token, { command: SUBSCRIBE });
       }
     };
 

--- a/packages/cloudvision-connector/src/logger.ts
+++ b/packages/cloudvision-connector/src/logger.ts
@@ -1,0 +1,54 @@
+/* eslint-disable no-console */
+
+import { LogLevels } from '../types';
+import { CloudVisionStatus } from '../types/notifications';
+
+import { ERROR, WARN } from './constants';
+
+/**
+ * Logs nicely formatted console log errors or wandings
+ */
+export function log(
+  level: LogLevels,
+  message: string | null,
+  status?: CloudVisionStatus,
+  token?: string,
+): void {
+  const contextualizedMessage = message ? `${level}: ${message}` : `${level}: No message provided`;
+  const statusMessage = status
+    ? `Status Code: ${status.code}, Status Message: ${status.message}`
+    : undefined;
+  const tokenMessage = token ? `Request Token: ${token}` : undefined;
+
+  console.groupCollapsed('[[ CloudVision Connector ]]');
+  switch (level) {
+    case ERROR:
+      if (tokenMessage) {
+        console.error(tokenMessage);
+      }
+      console.error(contextualizedMessage);
+      if (statusMessage) {
+        console.error(statusMessage);
+      }
+      break;
+    case WARN:
+      if (tokenMessage) {
+        console.warn(tokenMessage);
+      }
+      console.warn(contextualizedMessage);
+      if (statusMessage) {
+        console.warn(statusMessage);
+      }
+      break;
+    default:
+      if (tokenMessage) {
+        console.log(tokenMessage);
+      }
+      console.log(contextualizedMessage);
+      if (statusMessage) {
+        console.log(statusMessage);
+      }
+      break;
+  }
+  console.groupEnd();
+}

--- a/packages/cloudvision-connector/src/utils.ts
+++ b/packages/cloudvision-connector/src/utils.ts
@@ -19,7 +19,13 @@ import { encode, decode, Codec } from 'a-msgpack';
 import { fromByteArray, toByteArray } from 'base64-js';
 import MurmurHash3 from 'imurmurhash';
 
-import { NotifCallback, PlainObject, SubscriptionIdentifier, PublishCallback } from '../types';
+import {
+  NotifCallback,
+  PlainObject,
+  SubscriptionIdentifier,
+  PublishCallback,
+  RequestArgs,
+} from '../types';
 import {
   CloudVisionBatchedNotifications,
   CloudVisionBatchedResult,
@@ -206,33 +212,40 @@ export function makeNotifCallback(callback: NotifCallback, options: Options = {}
     result?: CloudVisionResult | CloudVisionBatchedResult | CloudVisionServiceResult,
     status?: CloudVisionStatus,
     token?: string,
+    requestArgs?: RequestArgs,
   ): void => {
     if (status && status.code === EOF_CODE) {
-      callback(null, undefined, status, token);
+      callback(null, undefined, status, token, requestArgs);
       return;
     }
     if (err) {
-      callback(`Error: ${err}\nOptions: ${JSON.stringify(options)}`, undefined, status, token);
+      callback(
+        `Error: ${err}\nOptions: ${JSON.stringify(options)}`,
+        undefined,
+        status,
+        token,
+        requestArgs,
+      );
       // Send an extra EOF response to mark notification as complete.
-      callback(null, undefined, { code: EOF_CODE }, token);
+      callback(null, undefined, { code: EOF_CODE }, token, requestArgs);
       return;
     }
 
     const datasets = result as CloudVisionDatasets;
     if (datasets && datasets.datasets) {
-      callback(null, datasets, status, token);
+      callback(null, datasets, status, token, requestArgs);
       return;
     }
 
     const notifs = result as CloudVisionNotifs | CloudVisionBatchedNotifications;
     if (notifs && notifs.dataset) {
-      callback(null, notifs, status, token);
+      callback(null, notifs, status, token, requestArgs);
       return;
     }
 
     // if none of the cases above apply, then it's a service request
     if (notifs) {
-      callback(null, notifs, status, token);
+      callback(null, notifs, status, token, requestArgs);
     }
   };
 

--- a/packages/cloudvision-connector/src/utils.ts
+++ b/packages/cloudvision-connector/src/utils.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-use-before-define */
-
 // Copyright (c) 2018, Arista Networks, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software
@@ -41,8 +39,9 @@ import {
 } from '../types/params';
 import { Options, CloudVisionPublishRequest, ServiceRequest } from '../types/query';
 
-import { ALL_SEARCH_TYPES, EOF_CODE, SEARCH_TYPE_ANY } from './constants';
+import { ALL_SEARCH_TYPES, ERROR, EOF_CODE, SEARCH_TYPE_ANY } from './constants';
 import Emitter from './emitter';
+import { log } from './logger';
 
 interface ExplicitSearchOptions extends SearchOptions {
   searchType: SearchType;
@@ -322,22 +321,22 @@ export function validateResponse(
   const notifResponse = response as CloudVisionNotifs;
   /* eslint-disable no-console */
   if (notifResponse.dataset && !notifResponse.dataset.name) {
-    console.error(`No key 'name' found in dataset for token ${token}`);
+    log(ERROR, "No key 'name' found in dataset", undefined, token);
     return;
   }
 
   if (notifResponse.dataset && !notifResponse.dataset.type) {
-    console.error(`No key 'type' found in dataset for token ${token}`);
+    log(ERROR, "No key 'type' found in dataset", undefined, token);
     return;
   }
 
   if (notifResponse.dataset && !notifResponse.notifications) {
-    console.error(`No key 'notifications' found in response for token ${token}`);
+    log(ERROR, "No key 'notifications' found in response", undefined, token);
     return;
   }
 
   if (!batch && notifResponse.dataset && !Array.isArray(notifResponse.notifications)) {
-    console.error(`Key 'notifications' is not an array for token ${token}`);
+    log(ERROR, "Key 'notifications' is not an array", undefined, token);
   }
   /* eslint-enable no-console */
 }

--- a/packages/cloudvision-connector/src/wrpc.ts
+++ b/packages/cloudvision-connector/src/wrpc.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 // Copyright (c) 2018, Arista Networks, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software
@@ -42,15 +40,17 @@ import {
   CONNECTED,
   DISCONNECTED,
   EOF_CODE,
+  ERROR,
   ID,
   PAUSE,
   PAUSED_CODE,
-  RESUME,
   PUBLISH,
-  SERVICE_REQUEST,
+  RESUME,
   SEARCH,
+  SERVICE_REQUEST,
 } from './constants';
 import Emitter from './emitter';
+import { log } from './logger';
 import Parser from './parser';
 import { createCloseParams, makeToken, validateResponse } from './utils';
 
@@ -221,7 +221,7 @@ class WRPC {
     try {
       this.sendMessage(closeToken, CLOSE, closeParams);
     } catch (err) {
-      console.error(err);
+      log(ERROR, err);
       this.removeStreamClosingState(streams, closeToken);
       callback(err, undefined, undefined, closeToken);
     }
@@ -411,7 +411,7 @@ class WRPC {
         this.enableOptions((err, _res, status, token): void => {
           // We're good to go
           if (status && status.code !== EOF_CODE) {
-            console.error(err, status, token);
+            log(ERROR, err, status, token);
           }
           this.connectionEvents.emit('connection', WRPC.CONNECTED, event);
         });
@@ -443,12 +443,12 @@ class WRPC {
           );
         }
       } catch (err) {
-        console.error(err);
+        log(ERROR, err);
         return;
       }
 
       if (!msg || !msg.token) {
-        console.error('No message body or message token');
+        log(ERROR, 'No message body or message token');
         return;
       }
 
@@ -469,7 +469,7 @@ class WRPC {
           resumeStatus?: CloudVisionStatus,
         ): void => {
           if (err) {
-            console.error(err, resumeStatus);
+            log(ERROR, err, resumeStatus);
           }
         };
         this.resume({ token }, cb);
@@ -525,7 +525,7 @@ class WRPC {
     try {
       this.sendMessage(token, command, params);
     } catch (err) {
-      console.error(err);
+      log(ERROR, err);
       notifAndUnBindCallback(err, undefined, undefined, token);
     }
   }

--- a/packages/cloudvision-connector/test/emitter.spec.ts
+++ b/packages/cloudvision-connector/test/emitter.spec.ts
@@ -15,9 +15,13 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import { GET } from '../src/constants';
 import Emitter from '../src/emitter';
+import { RequestArgs } from '../types';
 
 describe('Emitter', () => {
+  const requestArgs = { command: GET };
+
   test('should remove itself from callback during emit', () => {
     const emitter = new Emitter();
     const event = 'test';
@@ -25,22 +29,22 @@ describe('Emitter', () => {
     const fakeCallback1 = jest.fn();
     const fakeCallback2 = jest.fn();
     const fakeCallbackInner = jest.fn();
-    const callbackWithUnbind = (d: string | null) => {
+    const callbackWithUnbind = (_rq: RequestArgs | undefined, d: string | null) => {
       emitter.unbind(event, callbackWithUnbind);
       fakeCallbackInner(d);
     };
 
-    emitter.bind(event, fakeCallback1);
-    emitter.bind(event, callbackWithUnbind);
-    emitter.bind(event, fakeCallback2);
+    emitter.bind(event, requestArgs, fakeCallback1);
+    emitter.bind(event, requestArgs, callbackWithUnbind);
+    emitter.bind(event, requestArgs, fakeCallback2);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(3);
 
     emitter.emit(event, data);
 
-    expect(fakeCallback1).toHaveBeenCalledWith(data);
+    expect(fakeCallback1).toHaveBeenCalledWith(requestArgs, data);
     expect(fakeCallbackInner).toHaveBeenCalledWith(data);
-    expect(fakeCallback2).toHaveBeenCalledWith(data);
+    expect(fakeCallback2).toHaveBeenCalledWith(requestArgs, data);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(2);
     expect(emitter.getEventsMap().get(event)).toContain(fakeCallback1);
@@ -48,58 +52,98 @@ describe('Emitter', () => {
     expect(emitter.getEventsMap().get(event)).not.toContain(callbackWithUnbind);
   });
 
-  test('should delete the event entry, if there is only one', () => {
+  test('should delete the event and request entry, if there is only one', () => {
     const emitter = new Emitter();
     const event = 'test';
     const data = 'lol';
     const fakeCallbackInner = jest.fn();
-    const callbackWithUnbind = (d: string | null) => {
+    const callbackWithUnbind = (_rq: RequestArgs | undefined, d: string | null) => {
       emitter.unbind(event, callbackWithUnbind);
       fakeCallbackInner(d);
     };
 
-    emitter.bind(event, callbackWithUnbind);
+    emitter.bind(event, requestArgs, callbackWithUnbind);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(1);
+    expect(emitter.getRequestArgsMap().get(event)).toEqual(requestArgs);
 
     emitter.emit(event, data);
 
     expect(fakeCallbackInner).toHaveBeenCalledWith(data);
     expect(emitter.getEventsMap().get(event)).toBe(undefined);
+    expect(emitter.getRequestArgsMap().get(event)).toBe(undefined);
   });
 
-  test('should not unbind if callack is not present', () => {
+  test('should not unbind if callack or remove request data is not present', () => {
     const emitter = new Emitter();
     const event = 'test';
     const fakeCallback = jest.fn();
     const fakeCallback2 = jest.fn();
 
-    emitter.bind(event, fakeCallback);
+    emitter.bind(event, requestArgs, fakeCallback);
     emitter.unbind(event, fakeCallback2);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(1);
+    expect(emitter.getRequestArgsMap().get(event)).toEqual(requestArgs);
   });
 
-  test('should not unbind if event type is not present', () => {
+  test('should not unbind if event type or remove request data is not present', () => {
     const emitter = new Emitter();
     const event = 'test';
     const fakeCallback = jest.fn();
 
-    emitter.bind(event, fakeCallback);
+    emitter.bind(event, requestArgs, fakeCallback);
     emitter.unbind('test2', fakeCallback);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(1);
+    expect(emitter.getRequestArgsMap().get(event)).toEqual(requestArgs);
   });
 
-  test('should unbind if callack is present', () => {
+  test('should unbind if callack is present and remove request data', () => {
     const emitter = new Emitter();
     const event = 'test';
     const fakeCallback = jest.fn();
 
-    emitter.bind(event, fakeCallback);
+    emitter.bind(event, requestArgs, fakeCallback);
     emitter.unbind(event, fakeCallback);
 
     expect(emitter.getEventsMap().get(event)).toBe(undefined);
+    expect(emitter.getRequestArgsMap().get(event)).toBe(undefined);
+  });
+
+  test('should unbind if callack is present and but not remove shared request data', () => {
+    const emitter = new Emitter();
+    const event = 'test';
+    const fakeCallback = jest.fn();
+    const fakeCallback2 = jest.fn();
+
+    emitter.bind(event, requestArgs, fakeCallback);
+    emitter.bind(event, requestArgs, fakeCallback2);
+    expect(emitter.getEventsMap().get(event)).toHaveLength(2);
+
+    emitter.unbind(event, fakeCallback);
+
+    expect(emitter.getEventsMap().get(event)).toHaveLength(1);
+    expect(emitter.getRequestArgsMap().get(event)).toEqual(requestArgs);
+  });
+
+  test('`getRequestArgsMap` should return request args', () => {
+    const emitter = new Emitter();
+    const event = 'test';
+    const event2 = 'test2';
+    const fakeCallbackInner = jest.fn();
+    const fakeCallback1 = jest.fn();
+    const callbackWithUnbind = (_rq: RequestArgs | undefined, d: string | null) => {
+      emitter.unbind(event, callbackWithUnbind);
+      fakeCallbackInner(d);
+    };
+
+    emitter.bind(event, requestArgs, callbackWithUnbind);
+    emitter.bind(event2, requestArgs, fakeCallback1);
+
+    // @ts-ignore
+    expect(emitter.events.size).toBe(2);
+    expect(emitter.getRequestArgsMap().size).toBe(2);
   });
 
   test('`getEventsMap` should return events', () => {
@@ -108,41 +152,43 @@ describe('Emitter', () => {
     const event2 = 'test2';
     const fakeCallbackInner = jest.fn();
     const fakeCallback1 = jest.fn();
-    const callbackWithUnbind = (d: string | null) => {
+    const callbackWithUnbind = (_rq: RequestArgs | undefined, d: string | null) => {
       emitter.unbind(event, callbackWithUnbind);
       fakeCallbackInner(d);
     };
 
-    emitter.bind(event, callbackWithUnbind);
-    emitter.bind(event2, fakeCallback1);
+    emitter.bind(event, requestArgs, callbackWithUnbind);
+    emitter.bind(event2, requestArgs, fakeCallback1);
 
     // @ts-ignore
     expect(emitter.events.size).toBe(2);
     expect(emitter.getEventsMap().size).toBe(2);
   });
 
-  test('should clear all events for eventType on `unbindAll`', () => {
+  test('should clear all events and request data for eventType on `unbindAll`', () => {
     const emitter = new Emitter();
     const event = 'test';
     const event2 = 'test2';
     const fakeCallbackInner = jest.fn();
     const fakeCallback1 = jest.fn();
     const fakeCallback2 = jest.fn();
-    const callbackWithUnbind = (d: string | null) => {
+    const callbackWithUnbind = (_rq: RequestArgs | undefined, d: string | null) => {
       emitter.unbind(event, callbackWithUnbind);
       fakeCallbackInner(d);
     };
 
-    emitter.bind(event, callbackWithUnbind);
-    emitter.bind(event, fakeCallback2);
-    emitter.bind(event2, fakeCallback1);
+    emitter.bind(event, requestArgs, callbackWithUnbind);
+    emitter.bind(event, requestArgs, fakeCallback2);
+    emitter.bind(event2, requestArgs, fakeCallback1);
     expect(emitter.getEventsMap().get(event)).toHaveLength(2);
     expect(emitter.getEventsMap().size).toBe(2);
+    expect(emitter.getRequestArgsMap().get(event)).toEqual(requestArgs);
 
     emitter.unbindAll(event);
 
     expect(emitter.getEventsMap().get(event)).toBe(undefined);
     expect(emitter.getEventsMap().size).toBe(1);
+    expect(emitter.getRequestArgsMap().get(event)).toBe(undefined);
   });
 
   test('should not emit eventType if no callbacks present', () => {
@@ -150,10 +196,27 @@ describe('Emitter', () => {
     const event = 'test';
     const fakeCallback1 = jest.fn();
 
-    emitter.bind(event, fakeCallback1);
+    emitter.bind(event, requestArgs, fakeCallback1);
     emitter.emit('test1');
 
     expect(fakeCallback1).not.toHaveBeenCalled();
+  });
+
+  test('should include request args in emit', () => {
+    const emitter = new Emitter();
+    const event = 'test';
+    const otherArg = 'something';
+    const fakeCallback = jest.fn();
+    const fakeCallback1 = jest.fn();
+
+    emitter.bind(event, requestArgs, fakeCallback);
+    emitter.bind(event, requestArgs, fakeCallback1);
+
+    emitter.emit(event, otherArg);
+    expect(fakeCallback).toHaveBeenCalledWith(requestArgs, otherArg);
+
+    emitter.emit(event);
+    expect(fakeCallback).toHaveBeenCalledWith(requestArgs);
   });
 
   test('should clear events `Map` on close', () => {
@@ -161,11 +224,22 @@ describe('Emitter', () => {
     const event = 'test';
     const fakeCallback1 = jest.fn();
 
-    emitter.bind(event, fakeCallback1);
+    emitter.bind(event, requestArgs, fakeCallback1);
     emitter.close();
 
     expect(emitter.getEventsMap().get(event)).toBe(undefined);
     expect(emitter.getEventsMap().size).toBe(0);
+  });
+
+  test('should clear requestArgs `Map` on close', () => {
+    const emitter = new Emitter();
+    const event = 'test';
+    const fakeCallback1 = jest.fn();
+
+    emitter.bind(event, requestArgs, fakeCallback1);
+    emitter.close();
+
+    expect(emitter.getRequestArgsMap().get(event)).toBe(undefined);
   });
 
   test('should return true if `has` is called with a callback present in the emitter', () => {
@@ -173,7 +247,7 @@ describe('Emitter', () => {
     const event = 'test';
     const fakeCallback1 = jest.fn();
 
-    emitter.bind(event, fakeCallback1);
+    emitter.bind(event, requestArgs, fakeCallback1);
     expect(emitter.has(event)).toBe(true);
   });
 
@@ -183,7 +257,7 @@ describe('Emitter', () => {
     expect(emitter.has(event)).toBe(false);
 
     const fakeCallback1 = jest.fn();
-    emitter.bind(event, fakeCallback1);
+    emitter.bind(event, requestArgs, fakeCallback1);
     emitter.close();
     expect(emitter.has(event)).toBe(false);
   });

--- a/packages/cloudvision-connector/test/index.spec.ts
+++ b/packages/cloudvision-connector/test/index.spec.ts
@@ -375,6 +375,7 @@ describe('getAndSubscribe', () => {
         RESULT,
         undefined,
         subscriptionId.subscribe.token,
+        { command: SUBSCRIBE },
       );
     }
 
@@ -408,6 +409,7 @@ describe('getAndSubscribe', () => {
         undefined,
         ERROR_STATUS,
         subscriptionId.subscribe.token,
+        { command: SUBSCRIBE },
       );
     }
 
@@ -545,7 +547,7 @@ describe.each([
         }),
       );
 
-      expect(callback).toHaveBeenCalledWith(null, RESULT, undefined, token);
+      expect(callback).toHaveBeenCalledWith(null, RESULT, undefined, token, { command });
     }
 
     expect(token).not.toBeNull();
@@ -571,6 +573,7 @@ describe.each([
         undefined,
         ERROR_STATUS,
         token,
+        { command },
       );
     }
 
@@ -715,7 +718,9 @@ describe.each([
         }),
       );
 
-      expect(callback).toHaveBeenCalledWith(null, RESULT, undefined, subscriptionId.token);
+      expect(callback).toHaveBeenCalledWith(null, RESULT, undefined, subscriptionId.token, {
+        command,
+      });
     }
 
     expect(subscriptionId).not.toBeNull();
@@ -741,6 +746,7 @@ describe.each([
         undefined,
         ERROR_STATUS,
         subscriptionId.token,
+        { command },
       );
     }
 

--- a/packages/cloudvision-connector/test/index.spec.ts
+++ b/packages/cloudvision-connector/test/index.spec.ts
@@ -81,6 +81,8 @@ const ERROR_STATUS = {
   messages: ERROR_MESSAGE,
 };
 
+jest.spyOn(console, 'groupCollapsed').mockImplementation();
+
 describe('getCommandToken', () => {
   test('should return the proper token', () => {
     const conn = new Connector();

--- a/packages/cloudvision-connector/test/logger.spec.ts
+++ b/packages/cloudvision-connector/test/logger.spec.ts
@@ -1,0 +1,50 @@
+/* eslint-env jest */
+
+import { ERROR, INFO, WARN } from '../src/constants';
+import { log } from '../src/logger';
+import { LogLevels } from '../types';
+
+describe.each([
+  [ERROR, 'error'],
+  [INFO, 'log'],
+  [WARN, 'warn'],
+])('log', (level, fn) => {
+  const groupSpy = jest.spyOn(console, 'groupCollapsed');
+  // @ts-ignore spyOn uses the string name of the function
+  const consoleSpy = jest.spyOn(console, fn);
+  const message = 'Dodgers rule';
+  const status = { code: 0, message: 'Giants not that great' };
+  const token = 'MLB';
+
+  beforeEach(() => {
+    groupSpy.mockReset();
+    consoleSpy.mockReset();
+  });
+
+  test(`${level} should log a console group for just a message`, () => {
+    log(level as LogLevels, message);
+    expect(groupSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenNthCalledWith(1, `${level}: ${message}`);
+  });
+
+  test(`${level} should log a console group for a message and status`, () => {
+    log(level as LogLevels, message, status);
+    expect(groupSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenNthCalledWith(1, `${level}: ${message}`);
+    expect(consoleSpy).toHaveBeenNthCalledWith(
+      2,
+      `Status Code: ${status.code}, Status Message: ${status.message}`,
+    );
+  });
+
+  test(`${level} should log a console group for a message, status and token`, () => {
+    log(level as LogLevels, message, status, token);
+    expect(groupSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenNthCalledWith(1, `Request Token: ${token}`);
+    expect(consoleSpy).toHaveBeenNthCalledWith(2, `${level}: ${message}`);
+    expect(consoleSpy).toHaveBeenNthCalledWith(
+      3,
+      `Status Code: ${status.code}, Status Message: ${status.message}`,
+    );
+  });
+});

--- a/packages/cloudvision-connector/test/wrpc.spec.ts
+++ b/packages/cloudvision-connector/test/wrpc.spec.ts
@@ -39,7 +39,7 @@ import { log } from '../src/logger';
 import Parser from '../src/parser';
 import { makeToken } from '../src/utils';
 import WRPC from '../src/wrpc';
-import { NotifCallback, SubscriptionIdentifier } from '../types';
+import { NotifCallback, SubscriptionIdentifier, RequestArgs } from '../types';
 import { WsCommand, CloudVisionParams } from '../types/params';
 import { CloudVisionQueryMessage } from '../types/query';
 
@@ -198,6 +198,7 @@ describe.each([
   const wsCommand = command as WsCommand;
   let wrpc: WRPC;
   let ws: WebSocket;
+  let requestArgs: RequestArgs;
   let sendSpy: jest.SpyInstance;
   let eventsEmitterSpy: jest.SpyInstance;
   let eventsEmitterUnbindSpy: jest.SpyInstance;
@@ -221,6 +222,7 @@ describe.each([
     wrpc = new WRPC();
     // @ts-ignore
     commandFn = wrpc[fn];
+    requestArgs = { command };
     // @ts-ignore
     polymorphicCommandFn = wrpc[fn];
     wrpc.run('ws://localhost:8080');
@@ -268,7 +270,7 @@ describe.each([
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(sendSpy).toHaveBeenCalledWith(
         Parser.stringify({
@@ -305,10 +307,16 @@ describe.each([
         }),
       );
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(ERROR_MESSAGE, undefined, undefined, token);
-      expect(eventsEmitterSpy).not.toHaveBeenCalled();
+      expect(callbackSpy).toHaveBeenCalledWith(
+        ERROR_MESSAGE,
+        undefined,
+        undefined,
+        token,
+        requestArgs,
+      );
+      expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
     }
@@ -332,11 +340,17 @@ describe.each([
       );
 
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(ERROR_MESSAGE, undefined, ERROR_STATUS, token);
+      expect(callbackSpy).toHaveBeenCalledWith(
+        ERROR_MESSAGE,
+        undefined,
+        ERROR_STATUS,
+        token,
+        requestArgs,
+      );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, ERROR_MESSAGE, undefined, ERROR_STATUS);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
@@ -363,11 +377,11 @@ describe.each([
       );
 
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token);
+      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestArgs);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, EOF, undefined, EOF_STATUS);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
@@ -391,11 +405,11 @@ describe.each([
       );
 
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token);
+      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestArgs);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, null, RESULT, undefined);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -418,7 +432,7 @@ describe.each([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -441,7 +455,7 @@ describe.each([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -466,7 +480,7 @@ describe.each([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -488,6 +502,7 @@ describe.each([
   let NOW = 0;
   let wrpc: WRPC;
   let ws: WebSocket;
+  let requestArgs: RequestArgs;
   let sendSpy: jest.SpyInstance;
   let postMessageSpy: jest.SpyInstance;
   let eventsEmitterSpy: jest.SpyInstance;
@@ -518,6 +533,7 @@ describe.each([
     });
     // @ts-ignore
     commandFn = wrpc[fn];
+    requestArgs = { command };
     // @ts-ignore
     polymorphicCommandFn = wrpc[fn];
     wrpc.run('ws://localhost:8080');
@@ -561,7 +577,7 @@ describe.each([
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(sendSpy).toHaveBeenCalledWith(
         Parser.stringify({
@@ -600,11 +616,11 @@ describe.each([
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith(expectedPostedMessage, '*');
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token);
+      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestArgs);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(token).not.toBeNull();
     }
     expect(token).not.toBeNull();
@@ -685,7 +701,7 @@ describe.each([
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith(expectedPostedMessage, '*');
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token);
+      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestArgs);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(2);
@@ -721,12 +737,18 @@ describe.each([
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith(expectedPostedMessage, '*');
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(ERROR_MESSAGE, undefined, ERROR_STATUS, token);
+      expect(callbackSpy).toHaveBeenCalledWith(
+        ERROR_MESSAGE,
+        undefined,
+        ERROR_STATUS,
+        token,
+        requestArgs,
+      );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(token).not.toBeNull();
     }
     expect(token).not.toBeNull();
@@ -766,7 +788,13 @@ describe.each([
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith(expectedPostedMessage, '*');
       expect(callbackSpy).toHaveBeenCalledTimes(2);
-      expect(callbackSpy).toHaveBeenCalledWith(ERROR_MESSAGE, undefined, ERROR_STATUS, token);
+      expect(callbackSpy).toHaveBeenCalledWith(
+        ERROR_MESSAGE,
+        undefined,
+        ERROR_STATUS,
+        token,
+        requestArgs,
+      );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(2);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(2);
@@ -803,12 +831,12 @@ describe.each([
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith(expectedPostedMessage, '*');
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token);
+      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestArgs);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(token).not.toBeNull();
     }
     expect(token).not.toBeNull();
@@ -823,6 +851,7 @@ describe.each([
   const wsCommand = command as WsCommand;
   let wrpc: WRPC;
   let ws: WebSocket;
+  let requestArgs: RequestArgs;
   let sendSpy: jest.SpyInstance;
   let eventsEmitterSpy: jest.SpyInstance;
   let eventsEmitterUnbindSpy: jest.SpyInstance;
@@ -846,6 +875,7 @@ describe.each([
     wrpc = new WRPC();
     // @ts-ignore
     commandFn = wrpc[fn];
+    requestArgs = { command };
     wrpc.run('ws://localhost:8080');
     ws = wrpc.websocket;
     sendSpy = jest.spyOn(ws, 'send');
@@ -883,7 +913,7 @@ describe.each([
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(sendSpy).toHaveBeenCalledWith(
         Parser.stringify({
@@ -918,11 +948,11 @@ describe.each([
       );
       expect(wrpc.streams).toContain(token);
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(null, undefined, ACTIVE_STATUS, token);
+      expect(callbackSpy).toHaveBeenCalledWith(null, undefined, ACTIVE_STATUS, token, requestArgs);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, null, undefined, ACTIVE_STATUS);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(token).not.toBeNull();
     }
@@ -951,7 +981,7 @@ describe.each([
         expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
         expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(2);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
         expect(sendSpy).toHaveBeenCalledTimes(1);
         expect(sendSpy).toHaveBeenCalledWith(
           Parser.stringify({
@@ -991,7 +1021,7 @@ describe.each([
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(2);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(sendSpy).toHaveBeenCalledWith(
         Parser.stringify({
@@ -1027,10 +1057,16 @@ describe.each([
         }),
       );
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(ERROR_MESSAGE, undefined, undefined, token);
-      expect(eventsEmitterSpy).not.toHaveBeenCalled();
+      expect(callbackSpy).toHaveBeenCalledWith(
+        ERROR_MESSAGE,
+        undefined,
+        undefined,
+        token,
+        requestArgs,
+      );
+      expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
     }
@@ -1050,11 +1086,17 @@ describe.each([
       );
 
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(ERROR_MESSAGE, undefined, ERROR_STATUS, token);
+      expect(callbackSpy).toHaveBeenCalledWith(
+        ERROR_MESSAGE,
+        undefined,
+        ERROR_STATUS,
+        token,
+        requestArgs,
+      );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, ERROR_MESSAGE, undefined, ERROR_STATUS);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
@@ -1077,11 +1119,11 @@ describe.each([
       );
 
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token);
+      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestArgs);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, EOF, undefined, EOF_STATUS);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
@@ -1101,11 +1143,11 @@ describe.each([
       );
 
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token);
+      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestArgs);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, null, RESULT, undefined);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -1124,7 +1166,7 @@ describe.each([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -1143,7 +1185,7 @@ describe.each([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -1164,7 +1206,7 @@ describe.each([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -1181,6 +1223,7 @@ describe.each([
   const wsCommand = command as WsCommand;
   let wrpc: WRPC;
   let ws: WebSocket;
+  let requestArgs: RequestArgs;
   let subscriptionId: SubscriptionIdentifier;
   let subscriptionIdTwo: SubscriptionIdentifier;
   let sendSpy: jest.SpyInstance;
@@ -1307,6 +1350,7 @@ describe.each([
 
     test(`'${fn} + ${wsCommand}' should remove stream from closing map when EOF is received`, () => {
       const token = wrpc.closeStream(subscriptionId, closeCallback);
+      requestArgs = { command: CLOSE };
 
       if (token) {
         expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
@@ -1318,7 +1362,7 @@ describe.each([
 
         expect(wrpc.streamInClosingState).not.toContain(token);
         expect(closeCallback).toHaveBeenCalledTimes(1);
-        expect(closeCallback).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token);
+        expect(closeCallback).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestArgs);
         expect(callbackSpy).not.toHaveBeenCalled();
         expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
         expect(eventsEmitterSpy).toHaveBeenCalledWith(token, EOF, undefined, EOF_STATUS);
@@ -1328,13 +1372,14 @@ describe.each([
           subscriptionId.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       }
       expect(token).not.toBeNull();
     });
 
     test(`'${fn} + ${wsCommand}' should remove stream from closing map when any error is received`, () => {
       const token = wrpc.closeStream(subscriptionId, closeCallback);
+      requestArgs = { command: CLOSE };
 
       if (token) {
         expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
@@ -1346,7 +1391,13 @@ describe.each([
 
         expect(wrpc.streamInClosingState).not.toContain(token);
         expect(closeCallback).toHaveBeenCalledTimes(1);
-        expect(closeCallback).toHaveBeenCalledWith(ERROR_MESSAGE, undefined, ERROR_STATUS, token);
+        expect(closeCallback).toHaveBeenCalledWith(
+          ERROR_MESSAGE,
+          undefined,
+          ERROR_STATUS,
+          token,
+          requestArgs,
+        );
         expect(callbackSpy).not.toHaveBeenCalled();
         expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
         expect(eventsEmitterSpy).toHaveBeenCalledWith(
@@ -1361,7 +1412,7 @@ describe.each([
           subscriptionId.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       }
       expect(token).not.toBeNull();
     });
@@ -1417,6 +1468,7 @@ describe.each([
           undefined,
           ACTIVE_STATUS,
           subscriptionIdNew.token,
+          { command },
         );
 
         eventsEmitterSpy.mockClear();
@@ -1437,6 +1489,7 @@ describe.each([
           RESULT,
           undefined,
           subscriptionIdNew.token,
+          { command },
         );
       }
       expect(token).not.toBeNull();
@@ -1448,6 +1501,7 @@ describe.each([
     test(`'${fn} + ${wsCommand}' should send close message`, () => {
       const streams = [subscriptionId, subscriptionIdTwo];
       const token = wrpc.closeStreams(streams, closeCallback);
+      requestArgs = { command: CLOSE };
 
       if (token) {
         expect(closeCallback).not.toHaveBeenCalled();
@@ -1466,7 +1520,7 @@ describe.each([
           subscriptionIdTwo.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
         expect(sendSpy).toHaveBeenCalledTimes(1);
         expect(sendSpy).toHaveBeenCalledWith(
           Parser.stringify({
@@ -1486,6 +1540,7 @@ describe.each([
 
       const streams = [subscriptionId, subscriptionIdTwo];
       const token = wrpc.closeStreams(streams, closeCallback);
+      requestArgs = { command: CLOSE };
 
       if (token) {
         expect(closeCallback).toHaveBeenCalledTimes(1);
@@ -1505,7 +1560,7 @@ describe.each([
           subscriptionIdTwo.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
         expect(sendSpy).toHaveBeenCalledTimes(1);
         expect(sendSpy).toHaveBeenCalledWith(
           Parser.stringify({
@@ -1536,6 +1591,7 @@ describe.each([
     test(`'${fn} + ${wsCommand}' should remove stream from closing map when EOF is received`, () => {
       const streams = [subscriptionId, subscriptionIdTwo];
       const token = wrpc.closeStreams(streams, closeCallback);
+      requestArgs = { command: CLOSE };
 
       if (token) {
         expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
@@ -1547,7 +1603,7 @@ describe.each([
 
         expect(wrpc.streamInClosingState).not.toContain(token);
         expect(closeCallback).toHaveBeenCalledTimes(1);
-        expect(closeCallback).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token);
+        expect(closeCallback).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestArgs);
         expect(callbackSpy).not.toHaveBeenCalled();
         expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
         expect(eventsEmitterSpy).toHaveBeenCalledWith(token, EOF, undefined, EOF_STATUS);
@@ -1563,7 +1619,7 @@ describe.each([
           subscriptionIdTwo.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       }
       expect(token).not.toBeNull();
     });
@@ -1571,6 +1627,7 @@ describe.each([
     test(`'${fn} + ${wsCommand}' should remove stream from closing map when any error is received`, () => {
       const streams = [subscriptionId, subscriptionIdTwo];
       const token = wrpc.closeStreams(streams, closeCallback);
+      requestArgs = { command: CLOSE };
 
       if (token) {
         expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
@@ -1582,7 +1639,13 @@ describe.each([
 
         expect(wrpc.streamInClosingState).not.toContain(token);
         expect(closeCallback).toHaveBeenCalledTimes(1);
-        expect(closeCallback).toHaveBeenCalledWith(ERROR_MESSAGE, undefined, ERROR_STATUS, token);
+        expect(closeCallback).toHaveBeenCalledWith(
+          ERROR_MESSAGE,
+          undefined,
+          ERROR_STATUS,
+          token,
+          requestArgs,
+        );
         expect(callbackSpy).not.toHaveBeenCalled();
         expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
         expect(eventsEmitterSpy).toHaveBeenCalledWith(
@@ -1603,7 +1666,7 @@ describe.each([
           subscriptionIdTwo.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
       }
       expect(token).not.toBeNull();
     });
@@ -1666,6 +1729,7 @@ describe.each([
           undefined,
           ACTIVE_STATUS,
           subscriptionIdNew.token,
+          { command },
         );
 
         eventsEmitterSpy.mockClear();
@@ -1686,6 +1750,7 @@ describe.each([
           RESULT,
           undefined,
           subscriptionIdNew.token,
+          { command },
         );
       }
       expect(token).not.toBeNull();

--- a/packages/cloudvision-connector/types/emitter.ts
+++ b/packages/cloudvision-connector/types/emitter.ts
@@ -1,3 +1,4 @@
-import { EventCallback } from '.';
+import { EventCallback, RequestArgs } from '.';
 
 export type EmitterEvents = Map<string, EventCallback[]>;
+export type EmitterRequestArgs = Map<string, RequestArgs>;

--- a/packages/cloudvision-connector/types/index.ts
+++ b/packages/cloudvision-connector/types/index.ts
@@ -46,6 +46,11 @@ export type NotifCallback = (
   token?: string,
 ) => void;
 
+export type ERROR = 'ERROR';
+export type INFO = 'INFO';
+export type WARN = 'WARN';
+export type LogLevels = WARN | ERROR | INFO;
+
 export {
   CloudVisionDatapoint,
   CloudVisionDelete,

--- a/packages/cloudvision-connector/types/index.ts
+++ b/packages/cloudvision-connector/types/index.ts
@@ -4,6 +4,7 @@ import {
   CloudVisionServiceResult,
   CloudVisionStatus,
 } from './notifications';
+import { WsCommand } from './params';
 
 export { BaseType, Element, NeatType, NeatTypeClass, PathElements, Timestamp } from 'a-msgpack';
 
@@ -12,7 +13,10 @@ export interface PlainObject<T> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type EventCallback = (...args: any[]) => void;
+export type EventCallback = (requestArgs: RequestArgs | undefined, ...args: any[]) => void;
+export interface RequestArgs {
+  command: WsCommand | 'connection';
+}
 
 export type ConnectionCallback = (connEvent: string, wsEvent: Event) => void;
 
@@ -44,6 +48,7 @@ export type NotifCallback = (
   result?: CloudVisionBatchedResult | CloudVisionResult | CloudVisionServiceResult,
   status?: CloudVisionStatus,
   token?: string,
+  requestArgs?: RequestArgs,
 ) => void;
 
 export type ERROR = 'ERROR';


### PR DESCRIPTION
- Update console logging to add more context when internal errors happen
- Add additional context to callbacks. For now this context includes just the command (as queries can get pretty large and we don't want to use extra memory), but we can add other things as we see fit.