### PR TITLE
Fix/logging tests

### DIFF
--- a/packages/a-msgpack/jest.config.js
+++ b/packages/a-msgpack/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   coverageReporters: ['html', 'lcov'],
   collectCoverageFrom: [
     '**/*.ts',
+    '!src/index.ts',
     '!src/utils/utf8.ts',
     '!src/utils/prettyByte.ts',
     '!**/node_modules/**',

--- a/packages/a-msgpack/package.json
+++ b/packages/a-msgpack/package.json
@@ -28,10 +28,10 @@
     "test": "jest",
     "test:all": "npm run test && npm run test:purejs && npm run test:forcete",
     "test:clean": "rimraf .jest-cache",
-    "test:cov": "rimraf coverage && npm run test --coverage && npm run test:purejs --coverage && npm run test:forcete --coverage",
+    "test:cov": "rimraf coverage && npm run test -- --coverage && npm run test:purejs && npm run test:forcete -- --coverage",
     "test:forcete": "cross-env TEXT_ENCODING=force TEXT_DECODING=force jest",
-    "test:purejs": "cross-env TEXT_ENCODING=never jest",
-    "test:watch": "npm run test --watch",
+    "test:purejs": "cross-env TEXT_ENCODING=never TEXT_DECODING=never jest",
+    "test:watch": "npm run test -- --watch",
     "type-check": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/cloudvision-connector/jest.config.js
+++ b/packages/cloudvision-connector/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   coverageReporters: ['html', 'lcov'],
   collectCoverageFrom: [
     '**/*.ts',
+    '!src/index.ts',
     '!**/node_modules/**',
     '!**/lib/**',
     '!**/es/**',

--- a/packages/cloudvision-connector/package.json
+++ b/packages/cloudvision-connector/package.json
@@ -27,8 +27,8 @@
     "prettier-fix": "prettier --write *.js src/**/*.ts test/**/*.ts types/**/*.ts",
     "test": "cross-env NODE_ENV=production jest",
     "test:clean": "rimraf .jest-cache",
-    "test:cov": "rimraf coverage && npm run test --coverage",
-    "test:watch": "npm run test --watch",
+    "test:cov": "rimraf coverage && npm run test -- --coverage",
+    "test:watch": "npm run test -- --watch",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/cloudvision-connector/src/constants.ts
+++ b/packages/cloudvision-connector/src/constants.ts
@@ -15,7 +15,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { SearchType } from '../types';
+import { RequestContext, SearchType } from '../types';
 
 export const ERROR = 'ERROR';
 export const INFO = 'INFO';
@@ -70,3 +70,5 @@ export const ALL_SEARCH_TYPES = new Set<SearchType>([
 export const CONNECTED = 'connected';
 export const DISCONNECTED = 'disconnected';
 export const ID = 'cloudvision-connector';
+
+export const DEFAULT_CONTEXT: RequestContext = { command: 'NO_COMMAND' };

--- a/packages/cloudvision-connector/src/utils.ts
+++ b/packages/cloudvision-connector/src/utils.ts
@@ -34,7 +34,7 @@ import {
   Options,
   PublishCallback,
   Query,
-  RequestArgs,
+  RequestContext,
   SearchOptions,
   SearchType,
   ServiceRequest,
@@ -208,10 +208,10 @@ export function makeNotifCallback(callback: NotifCallback, options: Options = {}
     result?: CloudVisionResult | CloudVisionBatchedResult | CloudVisionServiceResult,
     status?: CloudVisionStatus,
     token?: string,
-    requestArgs?: RequestArgs,
+    requestContext?: RequestContext,
   ): void => {
     if (status && status.code === EOF_CODE) {
-      callback(null, undefined, status, token, requestArgs);
+      callback(null, undefined, status, token, requestContext);
       return;
     }
     if (err) {
@@ -220,28 +220,28 @@ export function makeNotifCallback(callback: NotifCallback, options: Options = {}
         undefined,
         status,
         token,
-        requestArgs,
+        requestContext,
       );
       // Send an extra EOF response to mark notification as complete.
-      callback(null, undefined, { code: EOF_CODE }, token, requestArgs);
+      callback(null, undefined, { code: EOF_CODE }, token, requestContext);
       return;
     }
 
     const datasets = result as CloudVisionDatasets;
     if (datasets && datasets.datasets) {
-      callback(null, datasets, status, token, requestArgs);
+      callback(null, datasets, status, token, requestContext);
       return;
     }
 
     const notifs = result as CloudVisionNotifs | CloudVisionBatchedNotifications;
     if (notifs && notifs.dataset) {
-      callback(null, notifs, status, token, requestArgs);
+      callback(null, notifs, status, token, requestContext);
       return;
     }
 
     // if none of the cases above apply, then it's a service request
     if (notifs) {
-      callback(null, notifs, status, token, requestArgs);
+      callback(null, notifs, status, token, requestContext);
     }
   };
 

--- a/packages/cloudvision-connector/test/Wrpc.spec.ts
+++ b/packages/cloudvision-connector/test/Wrpc.spec.ts
@@ -45,7 +45,7 @@ import {
   CloudVisionStatus,
   NotifCallback,
   QueryParams,
-  RequestArgs,
+  RequestContext,
   StreamCommand,
   SubscriptionIdentifier,
   WsCommand,
@@ -232,7 +232,7 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
 ])('Call Commands', (command, fn, polymorphic) => {
   let wrpc: Wrpc;
   let ws: WebSocket;
-  let requestArgs: RequestArgs;
+  let requestContext: RequestContext;
   let sendSpy: jest.SpyInstance;
   let eventsEmitterSpy: jest.SpyInstance;
   let eventsEmitterUnbindSpy: jest.SpyInstance;
@@ -252,7 +252,7 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     wrpc = new Wrpc();
     // @ts-ignore
     commandFn = wrpc[fn];
-    requestArgs = { command };
+    requestContext = { command };
     // @ts-ignore
     polymorphicCommandFn = wrpc[fn];
     wrpc.run('ws://localhost:8080');
@@ -300,7 +300,11 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(sendSpy).toHaveBeenCalledWith(
         Parser.stringify({
@@ -342,11 +346,15 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
         undefined,
         undefined,
         token,
-        requestArgs,
+        requestContext,
       );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
     }
@@ -375,12 +383,16 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
         undefined,
         ERROR_STATUS,
         token,
-        requestArgs,
+        requestContext,
       );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, ERROR_MESSAGE, undefined, ERROR_STATUS);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
@@ -407,11 +419,15 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       );
 
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestArgs);
+      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestContext);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, EOF, undefined, EOF_STATUS);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
@@ -435,11 +451,15 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       );
 
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestArgs);
+      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestContext);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, null, RESULT, undefined);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -462,7 +482,11 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -485,7 +509,11 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -510,7 +538,11 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -531,7 +563,7 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
   let NOW = 0;
   let wrpc: Wrpc;
   let ws: WebSocket;
-  let requestArgs: RequestArgs;
+  let requestContext: RequestContext;
   let sendSpy: jest.SpyInstance;
   let postMessageSpy: jest.SpyInstance;
   let eventsEmitterSpy: jest.SpyInstance;
@@ -558,7 +590,7 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     });
     // @ts-ignore
     commandFn = wrpc[fn];
-    requestArgs = { command };
+    requestContext = { command };
     // @ts-ignore
     polymorphicCommandFn = wrpc[fn];
     wrpc.run('ws://localhost:8080');
@@ -606,7 +638,11 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(sendSpy).toHaveBeenCalledWith(
         Parser.stringify({
@@ -645,11 +681,15 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith(expectedPostedMessage, '*');
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestArgs);
+      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestContext);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(token).not.toBeNull();
     }
     expect(token).not.toBeNull();
@@ -734,7 +774,7 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith(expectedPostedMessage, '*');
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestArgs);
+      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestContext);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(2);
@@ -775,13 +815,17 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
         undefined,
         ERROR_STATUS,
         token,
-        requestArgs,
+        requestContext,
       );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(token).not.toBeNull();
     }
     expect(token).not.toBeNull();
@@ -826,7 +870,7 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
         undefined,
         ERROR_STATUS,
         token,
-        requestArgs,
+        requestContext,
       );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(2);
@@ -864,12 +908,16 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith(expectedPostedMessage, '*');
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestArgs);
+      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestContext);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(token).not.toBeNull();
     }
     expect(token).not.toBeNull();
@@ -883,7 +931,7 @@ describe.each<[StreamCommand, 'stream']>([
 ])('Stream Commands', (command, fn) => {
   let wrpc: Wrpc;
   let ws: WebSocket;
-  let requestArgs: RequestArgs;
+  let requestContext: RequestContext;
   let sendSpy: jest.SpyInstance;
   let eventsEmitterSpy: jest.SpyInstance;
   let eventsEmitterUnbindSpy: jest.SpyInstance;
@@ -902,7 +950,7 @@ describe.each<[StreamCommand, 'stream']>([
     jest.resetAllMocks();
     wrpc = new Wrpc();
     commandFn = wrpc[fn];
-    requestArgs = { command };
+    requestContext = { command };
     wrpc.run('ws://localhost:8080');
     ws = wrpc.websocket;
     sendSpy = jest.spyOn(ws, 'send');
@@ -940,7 +988,11 @@ describe.each<[StreamCommand, 'stream']>([
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(sendSpy).toHaveBeenCalledWith(
         Parser.stringify({
@@ -975,11 +1027,21 @@ describe.each<[StreamCommand, 'stream']>([
       );
       expect(wrpc.streams).toContain(token);
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(null, undefined, ACTIVE_STATUS, token, requestArgs);
+      expect(callbackSpy).toHaveBeenCalledWith(
+        null,
+        undefined,
+        ACTIVE_STATUS,
+        token,
+        requestContext,
+      );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, null, undefined, ACTIVE_STATUS);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(token).not.toBeNull();
     }
@@ -1008,7 +1070,11 @@ describe.each<[StreamCommand, 'stream']>([
         expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
         expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(2);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+          token,
+          requestContext,
+          expect.any(Function),
+        );
         expect(sendSpy).toHaveBeenCalledTimes(1);
         expect(sendSpy).toHaveBeenCalledWith(
           Parser.stringify({
@@ -1048,7 +1114,11 @@ describe.each<[StreamCommand, 'stream']>([
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(2);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(sendSpy).toHaveBeenCalledWith(
         Parser.stringify({
@@ -1089,11 +1159,15 @@ describe.each<[StreamCommand, 'stream']>([
         undefined,
         undefined,
         token,
-        requestArgs,
+        requestContext,
       );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
     }
@@ -1118,12 +1192,16 @@ describe.each<[StreamCommand, 'stream']>([
         undefined,
         ERROR_STATUS,
         token,
-        requestArgs,
+        requestContext,
       );
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, ERROR_MESSAGE, undefined, ERROR_STATUS);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
@@ -1146,11 +1224,15 @@ describe.each<[StreamCommand, 'stream']>([
       );
 
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestArgs);
+      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestContext);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, EOF, undefined, EOF_STATUS);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
       expect(sendSpy).toHaveBeenCalledTimes(1);
@@ -1170,11 +1252,15 @@ describe.each<[StreamCommand, 'stream']>([
       );
 
       expect(callbackSpy).toHaveBeenCalledTimes(1);
-      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestArgs);
+      expect(callbackSpy).toHaveBeenCalledWith(null, RESULT, undefined, token, requestContext);
       expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
       expect(eventsEmitterSpy).toHaveBeenCalledWith(token, null, RESULT, undefined);
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -1193,7 +1279,11 @@ describe.each<[StreamCommand, 'stream']>([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -1212,7 +1302,11 @@ describe.each<[StreamCommand, 'stream']>([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -1233,7 +1327,11 @@ describe.each<[StreamCommand, 'stream']>([
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
       expect(sendSpy).toHaveBeenCalledTimes(1);
       expect(token).not.toBeNull();
@@ -1249,7 +1347,7 @@ describe.each<[StreamCommand, 'stream']>([
 ])('Close Stream Commands', (command, fn) => {
   let wrpc: Wrpc;
   let ws: WebSocket;
-  let requestArgs: RequestArgs;
+  let requestContext: RequestContext;
   let subscriptionId: SubscriptionIdentifier;
   let subscriptionIdTwo: SubscriptionIdentifier;
   let sendSpy: jest.SpyInstance;
@@ -1374,7 +1472,7 @@ describe.each<[StreamCommand, 'stream']>([
 
     test(`'${fn} + ${command}' should remove stream from closing map when EOF is received`, () => {
       const token = wrpc.closeStream(subscriptionId, closeCallback);
-      requestArgs = { command: CLOSE };
+      requestContext = { command: CLOSE };
 
       if (token) {
         expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
@@ -1386,7 +1484,13 @@ describe.each<[StreamCommand, 'stream']>([
 
         expect(wrpc.streamInClosingState).not.toContain(token);
         expect(closeCallback).toHaveBeenCalledTimes(1);
-        expect(closeCallback).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestArgs);
+        expect(closeCallback).toHaveBeenCalledWith(
+          EOF,
+          undefined,
+          EOF_STATUS,
+          token,
+          requestContext,
+        );
         expect(callbackSpy).not.toHaveBeenCalled();
         expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
         expect(eventsEmitterSpy).toHaveBeenCalledWith(token, EOF, undefined, EOF_STATUS);
@@ -1396,14 +1500,18 @@ describe.each<[StreamCommand, 'stream']>([
           subscriptionId.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+          token,
+          requestContext,
+          expect.any(Function),
+        );
       }
       expect(token).not.toBeNull();
     });
 
     test(`'${fn} + ${command}' should remove stream from closing map when any error is received`, () => {
       const token = wrpc.closeStream(subscriptionId, closeCallback);
-      requestArgs = { command: CLOSE };
+      requestContext = { command: CLOSE };
 
       if (token) {
         expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
@@ -1420,7 +1528,7 @@ describe.each<[StreamCommand, 'stream']>([
           undefined,
           ERROR_STATUS,
           token,
-          requestArgs,
+          requestContext,
         );
         expect(callbackSpy).not.toHaveBeenCalled();
         expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
@@ -1436,7 +1544,11 @@ describe.each<[StreamCommand, 'stream']>([
           subscriptionId.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+          token,
+          requestContext,
+          expect.any(Function),
+        );
       }
       expect(token).not.toBeNull();
     });
@@ -1525,7 +1637,7 @@ describe.each<[StreamCommand, 'stream']>([
     test(`'${fn} + ${command}' should send close message`, () => {
       const streams = [subscriptionId, subscriptionIdTwo];
       const token = wrpc.closeStreams(streams, closeCallback);
-      requestArgs = { command: CLOSE };
+      requestContext = { command: CLOSE };
 
       if (token) {
         expect(closeCallback).not.toHaveBeenCalled();
@@ -1544,7 +1656,11 @@ describe.each<[StreamCommand, 'stream']>([
           subscriptionIdTwo.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+          token,
+          requestContext,
+          expect.any(Function),
+        );
         expect(sendSpy).toHaveBeenCalledTimes(1);
         expect(sendSpy).toHaveBeenCalledWith(
           Parser.stringify({
@@ -1564,7 +1680,7 @@ describe.each<[StreamCommand, 'stream']>([
 
       const streams = [subscriptionId, subscriptionIdTwo];
       const token = wrpc.closeStreams(streams, closeCallback);
-      requestArgs = { command: CLOSE };
+      requestContext = { command: CLOSE };
 
       if (token) {
         expect(closeCallback).toHaveBeenCalledTimes(1);
@@ -1584,7 +1700,11 @@ describe.each<[StreamCommand, 'stream']>([
           subscriptionIdTwo.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+          token,
+          requestContext,
+          expect.any(Function),
+        );
         expect(sendSpy).toHaveBeenCalledTimes(1);
         expect(sendSpy).toHaveBeenCalledWith(
           Parser.stringify({
@@ -1615,7 +1735,7 @@ describe.each<[StreamCommand, 'stream']>([
     test(`'${fn} + ${command}' should remove stream from closing map when EOF is received`, () => {
       const streams = [subscriptionId, subscriptionIdTwo];
       const token = wrpc.closeStreams(streams, closeCallback);
-      requestArgs = { command: CLOSE };
+      requestContext = { command: CLOSE };
 
       if (token) {
         expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
@@ -1627,7 +1747,13 @@ describe.each<[StreamCommand, 'stream']>([
 
         expect(wrpc.streamInClosingState).not.toContain(token);
         expect(closeCallback).toHaveBeenCalledTimes(1);
-        expect(closeCallback).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestArgs);
+        expect(closeCallback).toHaveBeenCalledWith(
+          EOF,
+          undefined,
+          EOF_STATUS,
+          token,
+          requestContext,
+        );
         expect(callbackSpy).not.toHaveBeenCalled();
         expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
         expect(eventsEmitterSpy).toHaveBeenCalledWith(token, EOF, undefined, EOF_STATUS);
@@ -1643,7 +1769,11 @@ describe.each<[StreamCommand, 'stream']>([
           subscriptionIdTwo.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+          token,
+          requestContext,
+          expect.any(Function),
+        );
       }
       expect(token).not.toBeNull();
     });
@@ -1651,7 +1781,7 @@ describe.each<[StreamCommand, 'stream']>([
     test(`'${fn} + ${command}' should remove stream from closing map when any error is received`, () => {
       const streams = [subscriptionId, subscriptionIdTwo];
       const token = wrpc.closeStreams(streams, closeCallback);
-      requestArgs = { command: CLOSE };
+      requestContext = { command: CLOSE };
 
       if (token) {
         expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
@@ -1668,7 +1798,7 @@ describe.each<[StreamCommand, 'stream']>([
           undefined,
           ERROR_STATUS,
           token,
-          requestArgs,
+          requestContext,
         );
         expect(callbackSpy).not.toHaveBeenCalled();
         expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
@@ -1690,7 +1820,11 @@ describe.each<[StreamCommand, 'stream']>([
           subscriptionIdTwo.callback,
         );
         expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
-        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(token, requestArgs, expect.any(Function));
+        expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+          token,
+          requestContext,
+          expect.any(Function),
+        );
       }
       expect(token).not.toBeNull();
     });

--- a/packages/cloudvision-connector/test/emitter.spec.ts
+++ b/packages/cloudvision-connector/test/emitter.spec.ts
@@ -15,12 +15,12 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { GET } from '../src/constants';
+import { DEFAULT_CONTEXT, GET } from '../src/constants';
 import Emitter from '../src/emitter';
-import { EventCallback, RequestArgs } from '../types';
+import { EventCallback, RequestContext } from '../types';
 
 describe('Emitter', () => {
-  const requestArgs: RequestArgs = { command: GET };
+  const requestContext: RequestContext = { command: GET };
 
   test('should remove itself from callback during emit', () => {
     const emitter = new Emitter();
@@ -34,17 +34,17 @@ describe('Emitter', () => {
       fakeCallbackInner(d);
     };
 
-    emitter.bind(event, requestArgs, fakeCallback1);
-    emitter.bind(event, requestArgs, callbackWithUnbind);
-    emitter.bind(event, requestArgs, fakeCallback2);
+    emitter.bind(event, requestContext, fakeCallback1);
+    emitter.bind(event, requestContext, callbackWithUnbind);
+    emitter.bind(event, requestContext, fakeCallback2);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(3);
 
     emitter.emit(event, data);
 
-    expect(fakeCallback1).toHaveBeenCalledWith(requestArgs, data);
+    expect(fakeCallback1).toHaveBeenCalledWith(requestContext, data);
     expect(fakeCallbackInner).toHaveBeenCalledWith(data);
-    expect(fakeCallback2).toHaveBeenCalledWith(requestArgs, data);
+    expect(fakeCallback2).toHaveBeenCalledWith(requestContext, data);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(2);
     expect(emitter.getEventsMap().get(event)).toContain(fakeCallback1);
@@ -62,16 +62,16 @@ describe('Emitter', () => {
       fakeCallbackInner(d);
     };
 
-    emitter.bind(event, requestArgs, callbackWithUnbind);
+    emitter.bind(event, requestContext, callbackWithUnbind);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(1);
-    expect(emitter.getRequestArgsMap().get(event)).toEqual(requestArgs);
+    expect(emitter.getRequestContextMap().get(event)).toEqual(requestContext);
 
     emitter.emit(event, data);
 
     expect(fakeCallbackInner).toHaveBeenCalledWith(data);
     expect(emitter.getEventsMap().get(event)).toBe(undefined);
-    expect(emitter.getRequestArgsMap().get(event)).toBe(undefined);
+    expect(emitter.getRequestContextMap().get(event)).toBe(undefined);
   });
 
   test('should not unbind if callack or remove request data is not present', () => {
@@ -80,11 +80,11 @@ describe('Emitter', () => {
     const fakeCallback = jest.fn();
     const fakeCallback2 = jest.fn();
 
-    emitter.bind(event, requestArgs, fakeCallback);
+    emitter.bind(event, requestContext, fakeCallback);
     emitter.unbind(event, fakeCallback2);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(1);
-    expect(emitter.getRequestArgsMap().get(event)).toEqual(requestArgs);
+    expect(emitter.getRequestContextMap().get(event)).toEqual(requestContext);
   });
 
   test('should not unbind if event type or remove request data is not present', () => {
@@ -92,11 +92,11 @@ describe('Emitter', () => {
     const event = 'test';
     const fakeCallback = jest.fn();
 
-    emitter.bind(event, requestArgs, fakeCallback);
+    emitter.bind(event, requestContext, fakeCallback);
     emitter.unbind('test2', fakeCallback);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(1);
-    expect(emitter.getRequestArgsMap().get(event)).toEqual(requestArgs);
+    expect(emitter.getRequestContextMap().get(event)).toEqual(requestContext);
   });
 
   test('should unbind if callack is present and remove request data', () => {
@@ -104,11 +104,11 @@ describe('Emitter', () => {
     const event = 'test';
     const fakeCallback = jest.fn();
 
-    emitter.bind(event, requestArgs, fakeCallback);
+    emitter.bind(event, requestContext, fakeCallback);
     emitter.unbind(event, fakeCallback);
 
     expect(emitter.getEventsMap().get(event)).toBe(undefined);
-    expect(emitter.getRequestArgsMap().get(event)).toBe(undefined);
+    expect(emitter.getRequestContextMap().get(event)).toBe(undefined);
   });
 
   test('should unbind if callack is present and but not remove shared request data', () => {
@@ -117,17 +117,17 @@ describe('Emitter', () => {
     const fakeCallback = jest.fn();
     const fakeCallback2 = jest.fn();
 
-    emitter.bind(event, requestArgs, fakeCallback);
-    emitter.bind(event, requestArgs, fakeCallback2);
+    emitter.bind(event, requestContext, fakeCallback);
+    emitter.bind(event, requestContext, fakeCallback2);
     expect(emitter.getEventsMap().get(event)).toHaveLength(2);
 
     emitter.unbind(event, fakeCallback);
 
     expect(emitter.getEventsMap().get(event)).toHaveLength(1);
-    expect(emitter.getRequestArgsMap().get(event)).toEqual(requestArgs);
+    expect(emitter.getRequestContextMap().get(event)).toEqual(requestContext);
   });
 
-  test('`getRequestArgsMap` should return request args', () => {
+  test('`getRequestContextMap` should return request context', () => {
     const emitter = new Emitter();
     const event = 'test';
     const event2 = 'test2';
@@ -138,12 +138,12 @@ describe('Emitter', () => {
       fakeCallbackInner(d);
     };
 
-    emitter.bind(event, requestArgs, callbackWithUnbind);
-    emitter.bind(event2, requestArgs, fakeCallback1);
+    emitter.bind(event, requestContext, callbackWithUnbind);
+    emitter.bind(event2, requestContext, fakeCallback1);
 
     // @ts-ignore
     expect(emitter.events.size).toBe(2);
-    expect(emitter.getRequestArgsMap().size).toBe(2);
+    expect(emitter.getRequestContextMap().size).toBe(2);
   });
 
   test('`getEventsMap` should return events', () => {
@@ -157,8 +157,8 @@ describe('Emitter', () => {
       fakeCallbackInner(d);
     };
 
-    emitter.bind(event, requestArgs, callbackWithUnbind);
-    emitter.bind(event2, requestArgs, fakeCallback1);
+    emitter.bind(event, requestContext, callbackWithUnbind);
+    emitter.bind(event2, requestContext, fakeCallback1);
 
     // @ts-ignore
     expect(emitter.events.size).toBe(2);
@@ -177,18 +177,18 @@ describe('Emitter', () => {
       fakeCallbackInner(d);
     };
 
-    emitter.bind(event, requestArgs, callbackWithUnbind);
-    emitter.bind(event, requestArgs, fakeCallback2);
-    emitter.bind(event2, requestArgs, fakeCallback1);
+    emitter.bind(event, requestContext, callbackWithUnbind);
+    emitter.bind(event, requestContext, fakeCallback2);
+    emitter.bind(event2, requestContext, fakeCallback1);
     expect(emitter.getEventsMap().get(event)).toHaveLength(2);
     expect(emitter.getEventsMap().size).toBe(2);
-    expect(emitter.getRequestArgsMap().get(event)).toEqual(requestArgs);
+    expect(emitter.getRequestContextMap().get(event)).toEqual(requestContext);
 
     emitter.unbindAll(event);
 
     expect(emitter.getEventsMap().get(event)).toBe(undefined);
     expect(emitter.getEventsMap().size).toBe(1);
-    expect(emitter.getRequestArgsMap().get(event)).toBe(undefined);
+    expect(emitter.getRequestContextMap().get(event)).toBe(undefined);
   });
 
   test('should not emit eventType if no callbacks present', () => {
@@ -196,27 +196,46 @@ describe('Emitter', () => {
     const event = 'test';
     const fakeCallback1 = jest.fn();
 
-    emitter.bind(event, requestArgs, fakeCallback1);
+    emitter.bind(event, requestContext, fakeCallback1);
     emitter.emit('test1');
 
     expect(fakeCallback1).not.toHaveBeenCalled();
   });
 
-  test('should include request args in emit', () => {
+  test('should include request context in emit', () => {
     const emitter = new Emitter();
     const event = 'test';
     const otherArg = 'something';
     const fakeCallback = jest.fn();
     const fakeCallback1 = jest.fn();
 
-    emitter.bind(event, requestArgs, fakeCallback);
-    emitter.bind(event, requestArgs, fakeCallback1);
+    emitter.bind(event, requestContext, fakeCallback);
+    emitter.bind(event, requestContext, fakeCallback1);
 
     emitter.emit(event, otherArg);
-    expect(fakeCallback).toHaveBeenCalledWith(requestArgs, otherArg);
+    expect(fakeCallback).toHaveBeenCalledWith(requestContext, otherArg);
 
     emitter.emit(event);
-    expect(fakeCallback).toHaveBeenCalledWith(requestArgs);
+    expect(fakeCallback).toHaveBeenCalledWith(requestContext);
+  });
+
+  test('should include default request context in emit, if none is found', () => {
+    const emitter = new Emitter();
+    const event = 'test';
+    const otherArg = 'something';
+    const fakeCallback = jest.fn();
+    const fakeCallback1 = jest.fn();
+
+    // @ts-ignore setup for callback that is missing request context
+    emitter.bind(event, undefined, fakeCallback);
+    // @ts-ignore setup for callback that is missing request context
+    emitter.bind(event, undefined, fakeCallback1);
+
+    emitter.emit(event, otherArg);
+    expect(fakeCallback).toHaveBeenCalledWith(DEFAULT_CONTEXT, otherArg);
+
+    emitter.emit(event);
+    expect(fakeCallback).toHaveBeenCalledWith(DEFAULT_CONTEXT);
   });
 
   test('should clear events `Map` on close', () => {
@@ -224,22 +243,22 @@ describe('Emitter', () => {
     const event = 'test';
     const fakeCallback1 = jest.fn();
 
-    emitter.bind(event, requestArgs, fakeCallback1);
+    emitter.bind(event, requestContext, fakeCallback1);
     emitter.close();
 
     expect(emitter.getEventsMap().get(event)).toBe(undefined);
     expect(emitter.getEventsMap().size).toBe(0);
   });
 
-  test('should clear requestArgs `Map` on close', () => {
+  test('should clear requestContext `Map` on close', () => {
     const emitter = new Emitter();
     const event = 'test';
     const fakeCallback1 = jest.fn();
 
-    emitter.bind(event, requestArgs, fakeCallback1);
+    emitter.bind(event, requestContext, fakeCallback1);
     emitter.close();
 
-    expect(emitter.getRequestArgsMap().get(event)).toBe(undefined);
+    expect(emitter.getRequestContextMap().get(event)).toBe(undefined);
   });
 
   test('should return true if `has` is called with a callback present in the emitter', () => {
@@ -247,7 +266,7 @@ describe('Emitter', () => {
     const event = 'test';
     const fakeCallback1 = jest.fn();
 
-    emitter.bind(event, requestArgs, fakeCallback1);
+    emitter.bind(event, requestContext, fakeCallback1);
     expect(emitter.has(event)).toBe(true);
   });
 
@@ -257,7 +276,7 @@ describe('Emitter', () => {
     expect(emitter.has(event)).toBe(false);
 
     const fakeCallback1 = jest.fn();
-    emitter.bind(event, requestArgs, fakeCallback1);
+    emitter.bind(event, requestContext, fakeCallback1);
     emitter.close();
     expect(emitter.has(event)).toBe(false);
   });

--- a/packages/cloudvision-connector/test/logger.spec.ts
+++ b/packages/cloudvision-connector/test/logger.spec.ts
@@ -21,6 +21,12 @@ describe.each<[LogLevel, string]>([
     consoleSpy.mockReset();
   });
 
+  test(`${level} should log a console group with the default message there is no message`, () => {
+    log(level, null);
+    expect(groupSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenNthCalledWith(1, `${level}: No message provided`);
+  });
+
   test(`${level} should log a console group for just a message`, () => {
     log(level, message);
     expect(groupSpy).toHaveBeenCalledTimes(1);

--- a/packages/cloudvision-connector/test/utils.spec.ts
+++ b/packages/cloudvision-connector/test/utils.spec.ts
@@ -57,7 +57,7 @@ import {
   CloudVisionStatus,
   Options,
   Query,
-  RequestArgs,
+  RequestContext,
   SearchOptions,
   SubscriptionIdentifier,
 } from '../types';
@@ -313,7 +313,7 @@ describe('makeToken', () => {
 
 describe('makeNotifCallback', () => {
   const token = 'Dodgers';
-  const requestArgs: RequestArgs = { command: GET };
+  const requestContext: RequestContext = { command: GET };
   const callbackSpy = jest.fn();
 
   beforeEach(() => {
@@ -331,10 +331,10 @@ describe('makeNotifCallback', () => {
   test('should send undefined on `EOF`', () => {
     const notifCallback = makeNotifCallback(callbackSpy);
 
-    notifCallback(EOF, undefined, EOF_STATUS, token, requestArgs);
+    notifCallback(EOF, undefined, EOF_STATUS, token, requestContext);
 
     expect(callbackSpy).toHaveBeenCalledTimes(1);
-    expect(callbackSpy).toHaveBeenCalledWith(null, undefined, EOF_STATUS, token, requestArgs);
+    expect(callbackSpy).toHaveBeenCalledWith(null, undefined, EOF_STATUS, token, requestContext);
   });
 
   test('should invoke a callack with the result, when there is no error', () => {
@@ -347,10 +347,10 @@ describe('makeNotifCallback', () => {
       ],
     };
 
-    notifCallback(null, notif, undefined, token, requestArgs);
+    notifCallback(null, notif, undefined, token, requestContext);
 
     expect(callbackSpy).toHaveBeenCalledTimes(1);
-    expect(callbackSpy).toHaveBeenCalledWith(null, notif, undefined, token, requestArgs);
+    expect(callbackSpy).toHaveBeenCalledWith(null, notif, undefined, token, requestContext);
   });
 
   test('should invoke the callback properly for dataset responses', () => {
@@ -368,10 +368,10 @@ describe('makeNotifCallback', () => {
       ],
     };
 
-    notifCallback(null, notif, undefined, token, requestArgs);
+    notifCallback(null, notif, undefined, token, requestContext);
 
     expect(callbackSpy).toHaveBeenCalledTimes(1);
-    expect(callbackSpy).toHaveBeenCalledWith(null, notif, undefined, token, requestArgs);
+    expect(callbackSpy).toHaveBeenCalledWith(null, notif, undefined, token, requestContext);
   });
 
   test('should invoke the callback properly for service responses', () => {
@@ -380,17 +380,17 @@ describe('makeNotifCallback', () => {
       Dodgers: 'the best team in baseball',
     };
 
-    notifCallback(null, notif, undefined, token, requestArgs);
+    notifCallback(null, notif, undefined, token, requestContext);
 
     expect(callbackSpy).toHaveBeenCalledTimes(1);
-    expect(callbackSpy).toHaveBeenCalledWith(null, notif, undefined, token, requestArgs);
+    expect(callbackSpy).toHaveBeenCalledWith(null, notif, undefined, token, requestContext);
   });
 
   test('should invoke the callback if there is an error', () => {
     const notifCallback = makeNotifCallback(callbackSpy);
     const errorText = 'Some Error';
 
-    notifCallback(errorText, undefined, undefined, token, requestArgs);
+    notifCallback(errorText, undefined, undefined, token, requestContext);
 
     expect(callbackSpy).toHaveBeenCalledTimes(2);
     expect(callbackSpy).toHaveBeenLastCalledWith(
@@ -398,7 +398,7 @@ describe('makeNotifCallback', () => {
       undefined,
       { code: EOF_CODE },
       token,
-      requestArgs,
+      requestContext,
     );
     expect(callbackSpy.mock.calls[0][0]).toContain(errorText);
   });
@@ -412,7 +412,7 @@ describe('createCloseParams', () => {
     token: streamToken,
     callback: streamCallback,
   };
-  const requestArgs: RequestArgs = { command: SUBSCRIBE };
+  const requestContext: RequestContext = { command: SUBSCRIBE };
   const streamCallback2 = jest.fn();
   const streamToken2 = 'VinScully';
   const stream2: SubscriptionIdentifier = {
@@ -422,8 +422,8 @@ describe('createCloseParams', () => {
 
   beforeEach(() => {
     emitter = new Emitter();
-    emitter.bind(streamToken, requestArgs, streamCallback);
-    emitter.bind(streamToken2, requestArgs, streamCallback2);
+    emitter.bind(streamToken, requestContext, streamCallback);
+    emitter.bind(streamToken2, requestContext, streamCallback2);
   });
 
   test('should create the proper stream close params for one stream', () => {
@@ -453,7 +453,7 @@ describe('createCloseParams', () => {
     () => {
       const anotherCallback = jest.fn();
       const expectedCloseParams = null;
-      emitter.bind(streamToken, requestArgs, anotherCallback);
+      emitter.bind(streamToken, requestContext, anotherCallback);
 
       const closeParams = createCloseParams(stream, emitter);
 
@@ -475,7 +475,7 @@ describe('createCloseParams', () => {
         callback: anotherCallback,
       };
       const streams = [stream, annotherStream];
-      emitter.bind(streamToken, requestArgs, anotherCallback);
+      emitter.bind(streamToken, requestContext, anotherCallback);
 
       const closeParams = createCloseParams(streams, emitter);
 

--- a/packages/cloudvision-connector/types/connection.ts
+++ b/packages/cloudvision-connector/types/connection.ts
@@ -2,11 +2,11 @@ import { WsCommand } from './params';
 
 export interface EventCallback {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (requestArgs: RequestArgs | undefined, ...args: any[]): void;
+  (requestContext: RequestContext, ...args: any[]): void;
 }
 
-export interface RequestArgs {
-  command: WsCommand | 'connection';
+export interface RequestContext {
+  command: WsCommand | 'connection' | 'NO_COMMAND';
 }
 
 export interface ConnectionCallback {

--- a/packages/cloudvision-connector/types/emitter.ts
+++ b/packages/cloudvision-connector/types/emitter.ts
@@ -1,5 +1,5 @@
-import { EventCallback, RequestArgs } from './connection';
+import { EventCallback, RequestContext } from './connection';
 
 export type EmitterEvents = Map<string, EventCallback[]>;
 
-export type EmitterRequestArgs = Map<string, RequestArgs>;
+export type EmitterRequestContext = Map<string, RequestContext>;

--- a/packages/cloudvision-connector/types/notifications.ts
+++ b/packages/cloudvision-connector/types/notifications.ts
@@ -1,6 +1,6 @@
 import { PathElements, Timestamp } from 'a-msgpack';
 
-import { RequestArgs } from './connection';
+import { RequestContext } from './connection';
 import { DatasetObject } from './params';
 
 export interface CloudVisionDatasets {
@@ -114,6 +114,6 @@ export interface NotifCallback {
     result?: CloudVisionBatchedResult | CloudVisionResult | CloudVisionServiceResult,
     status?: CloudVisionStatus,
     token?: string,
-    requestArgs?: RequestArgs,
+    requestContext?: RequestContext,
   ): void;
 }


### PR DESCRIPTION
- Fix tests and test coverage
- Rename request args related types to 'context', which seems more natural
- Fix logging, so that we always pass a default context, instead of undefined