### PR TITLE
chore(renovate): enable automerge for dep updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,12 @@
   ],
   "assignees": ["rufman"],
   "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "branch"
+    }
+  ],
   "schedule": ["after 10pm and before 5am on every weekday", "every weekend"]
 }


### PR DESCRIPTION
Only open Prs for major version updates, or when some tests fail.