### PR TITLE
fix(connector): add logic to close get requests

### DIFF
--- a/packages/cloudvision-connector/src/utils.ts
+++ b/packages/cloudvision-connector/src/utils.ts
@@ -258,18 +258,11 @@ export function createCloseParams(
   eventsMap: Emitter,
 ): CloseParams | null {
   const closeParams: CloseParams = {};
-  if (Array.isArray(streams)) {
-    const streamsLen = streams.length;
-    for (let i = 0; i < streamsLen; i += 1) {
-      const { token, callback } = streams[i];
-      const remainingCallbacks = eventsMap.unbind(token, callback);
-      // Get number of registered callbacks for each stream, to determine which to close
-      if (remainingCallbacks === 0) {
-        closeParams[token] = true;
-      }
-    }
-  } else {
-    const { token, callback } = streams;
+  const streamArr = Array.isArray(streams) ? streams : [streams];
+
+  const streamsLen = streamArr.length;
+  for (let i = 0; i < streamsLen; i += 1) {
+    const { token, callback } = streamArr[i];
     const remainingCallbacks = eventsMap.unbind(token, callback);
     // Get number of registered callbacks for each stream, to determine which to close
     if (remainingCallbacks === 0) {

--- a/packages/cloudvision-connector/test/Wrpc.spec.ts
+++ b/packages/cloudvision-connector/test/Wrpc.spec.ts
@@ -295,6 +295,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
+    }
     if (token) {
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
@@ -329,6 +332,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
     }
     if (token) {
       expect(log).toHaveBeenCalledTimes(1);
@@ -369,6 +375,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
     }
     if (token) {
       ws.dispatchEvent(
@@ -411,6 +420,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
+    }
     if (token) {
       ws.dispatchEvent(
         new MessageEvent('message', {
@@ -445,6 +457,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
+    }
     if (token) {
       ws.dispatchEvent(
         new MessageEvent('message', { data: stringifyMessage({ token, result: RESULT }) }),
@@ -476,6 +491,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
+    }
     if (token) {
       ws.dispatchEvent(new MessageEvent('message', { data: RESULT }));
 
@@ -502,6 +520,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
     }
     if (token) {
       ws.dispatchEvent(new MessageEvent('message', { data: stringifyMessage({ result: RESULT }) }));
@@ -530,6 +551,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
     }
     if (token) {
       ws.dispatchEvent(new MessageEvent('message', { data: result }));
@@ -621,6 +645,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
+    }
     const expectedMessage: CloudVisionQueryMessage = {
       token,
       command,
@@ -666,6 +693,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
+    }
     const expectedPostedMessage: PostedMessage = {
       response: { token, result: RESULT },
       source: ID,
@@ -705,6 +735,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
+    }
     const expectedMessage: CloudVisionQueryMessage = {
       token,
       command,
@@ -721,6 +754,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, params, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
     }
 
     if (token) {
@@ -752,6 +788,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
+    }
     const expectedPostedMessage: PostedMessage = {
       response: { token, result: RESULT },
       source: ID,
@@ -763,6 +802,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, params, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
     }
 
     if (token) {
@@ -792,6 +834,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, params, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
     }
     const expectedPostedMessage: PostedMessage = {
       response: { token, error: ERROR_MESSAGE, status: ERROR_STATUS },
@@ -841,6 +886,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
+    }
     const expectedPostedMessage: PostedMessage = {
       response: { token, error: ERROR_MESSAGE, status: ERROR_STATUS },
       source: ID,
@@ -852,6 +900,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, params, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
     }
 
     if (token) {
@@ -890,6 +941,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, params, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as SubscriptionIdentifier).token;
     }
     const expectedPostedMessage: PostedMessage = {
       response: { token, error: EOF, status: EOF_STATUS },


### PR DESCRIPTION
GET requests associated with a subscribe should be closed when the
subscribe is closed. The lack of this functionality caused a race
condition in the worker-based middleware when a subscription was closed
and re-opened before the associated GET request returned.

Return SubscriptionIdentifier from callCommand.
Return SubscriptionIdentifier instead of token from get and
getWithOptions.
Create map from subscribe callbacks to GET SubscriptionIdentifier's
associated with them.
Add logic to close GET's related to streams in closeStream and
closeStreams.
Add logic to delete tokens from wrpc.activeRequests in
setStreamClosingState.
Revise createCloseParams to remove repeated logic.
Add handling to Connector.spec and Wrpc.spec for get/getWithOptions
returning a SubscriptionIdentifier instead of a simple token.