### PR TITLE
fix(connector): add logic to close get requests

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.2.0"
+  "version": "4.2.1-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,6 @@
 {
   "command": {
     "publish": {
-      "allowBranch": "master",
       "ignoreChanges": [
         "**/.eslintrc",
         "**/.gitignore",

--- a/packages/a-msgpack/package-lock.json
+++ b/packages/a-msgpack/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "a-msgpack",
-	"version": "4.2.0",
+	"version": "4.2.1-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/a-msgpack/package.json
+++ b/packages/a-msgpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a-msgpack",
-  "version": "4.2.0",
+  "version": "4.2.1-alpha.0",
   "description": "A minimalistic NEAT (MessagePack based) encoder and decoder for JavaScript.",
   "author": "Stephane Rufer <stephane@arista.com>",
   "homepage": "http://www.arista.com",

--- a/packages/cloudvision-connector/package-lock.json
+++ b/packages/cloudvision-connector/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cloudvision-connector",
-	"version": "4.2.0",
+	"version": "4.2.1-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cloudvision-connector/package.json
+++ b/packages/cloudvision-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudvision-connector",
-  "version": "4.2.0",
+  "version": "4.2.1-alpha.0",
   "description": "A module to communicate with the CloudVision API server",
   "author": "extensions@arista.com",
   "homepage": "http://www.arista.com",
@@ -50,7 +50,7 @@
     "switch"
   ],
   "dependencies": {
-    "a-msgpack": "4.2.0",
+    "a-msgpack": "^4.2.1-alpha.0",
     "base64-js": "1.3.1",
     "imurmurhash": "0.1.4",
     "jsbi": "3.1.2"

--- a/packages/cloudvision-connector/src/utils.ts
+++ b/packages/cloudvision-connector/src/utils.ts
@@ -38,7 +38,7 @@ import {
   SearchOptions,
   SearchType,
   ServiceRequest,
-  SubscriptionIdentifier,
+  RequestIdentifier,
   WsCommand,
 } from '../types';
 
@@ -254,24 +254,17 @@ export function makeNotifCallback(callback: NotifCallback, options: Options = {}
  * close params.
  */
 export function createCloseParams(
-  streams: SubscriptionIdentifier[] | SubscriptionIdentifier,
+  requests: RequestIdentifier[] | RequestIdentifier,
   eventsMap: Emitter,
 ): CloseParams | null {
   const closeParams: CloseParams = {};
-  if (Array.isArray(streams)) {
-    const streamsLen = streams.length;
-    for (let i = 0; i < streamsLen; i += 1) {
-      const { token, callback } = streams[i];
-      const remainingCallbacks = eventsMap.unbind(token, callback);
-      // Get number of registered callbacks for each stream, to determine which to close
-      if (remainingCallbacks === 0) {
-        closeParams[token] = true;
-      }
-    }
-  } else {
-    const { token, callback } = streams;
+  const requestArray = Array.isArray(requests) ? requests : [requests];
+
+  const requestsLen = requestArray.length;
+  for (let i = 0; i < requestsLen; i += 1) {
+    const { token, callback } = requestArray[i];
     const remainingCallbacks = eventsMap.unbind(token, callback);
-    // Get number of registered callbacks for each stream, to determine which to close
+    // Get number of registered callbacks for each request, to determine which to close
     if (remainingCallbacks === 0) {
       closeParams[token] = true;
     }

--- a/packages/cloudvision-connector/test/Wrpc.spec.ts
+++ b/packages/cloudvision-connector/test/Wrpc.spec.ts
@@ -47,7 +47,7 @@ import {
   QueryParams,
   RequestContext,
   StreamCommand,
-  SubscriptionIdentifier,
+  RequestIdentifier,
   WsCommand,
 } from '../types';
 
@@ -295,6 +295,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
+    }
     if (token) {
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
@@ -329,6 +332,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
     }
     if (token) {
       expect(log).toHaveBeenCalledTimes(1);
@@ -369,6 +375,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
     }
     if (token) {
       ws.dispatchEvent(
@@ -411,6 +420,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
+    }
     if (token) {
       ws.dispatchEvent(
         new MessageEvent('message', {
@@ -445,6 +457,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
+    }
     if (token) {
       ws.dispatchEvent(
         new MessageEvent('message', { data: stringifyMessage({ token, result: RESULT }) }),
@@ -476,6 +491,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
+    }
     if (token) {
       ws.dispatchEvent(new MessageEvent('message', { data: RESULT }));
 
@@ -502,6 +520,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
     }
     if (token) {
       ws.dispatchEvent(new MessageEvent('message', { data: stringifyMessage({ result: RESULT }) }));
@@ -530,6 +551,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
     }
     if (token) {
       ws.dispatchEvent(new MessageEvent('message', { data: result }));
@@ -621,6 +645,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
+    }
     const expectedMessage: CloudVisionQueryMessage = {
       token,
       command,
@@ -666,6 +693,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
+    }
     const expectedPostedMessage: PostedMessage = {
       response: { token, result: RESULT },
       source: ID,
@@ -705,6 +735,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
+    }
     const expectedMessage: CloudVisionQueryMessage = {
       token,
       command,
@@ -721,6 +754,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, params, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
     }
 
     if (token) {
@@ -752,6 +788,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
+    }
     const expectedPostedMessage: PostedMessage = {
       response: { token, result: RESULT },
       source: ID,
@@ -763,6 +802,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, params, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
     }
 
     if (token) {
@@ -792,6 +834,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, params, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
     }
     const expectedPostedMessage: PostedMessage = {
       response: { token, error: ERROR_MESSAGE, status: ERROR_STATUS },
@@ -841,6 +886,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
     }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
+    }
     const expectedPostedMessage: PostedMessage = {
       response: { token, error: ERROR_MESSAGE, status: ERROR_STATUS },
       source: ID,
@@ -852,6 +900,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, params, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
     }
 
     if (token) {
@@ -890,6 +941,9 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
       token = polymorphicCommandFn.call(wrpc, command, params, callbackSpy);
     } else {
       token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token && typeof token !== 'string') {
+      token = (token as RequestIdentifier).token;
     }
     const expectedPostedMessage: PostedMessage = {
       response: { token, error: EOF, status: EOF_STATUS },
@@ -1348,8 +1402,8 @@ describe.each<[StreamCommand, 'stream']>([
   let wrpc: Wrpc;
   let ws: WebSocket;
   let requestContext: RequestContext;
-  let subscriptionId: SubscriptionIdentifier;
-  let subscriptionIdTwo: SubscriptionIdentifier;
+  let subscriptionId: RequestIdentifier;
+  let subscriptionIdTwo: RequestIdentifier;
   let sendSpy: jest.SpyInstance;
   let eventsEmitterSpy: jest.SpyInstance;
   let eventsEmitterUnbindSpy: jest.SpyInstance;
@@ -1414,7 +1468,7 @@ describe.each<[StreamCommand, 'stream']>([
 
   describe('single stream', () => {
     test(`'${fn} + ${command}' should send close stream message`, () => {
-      const token = wrpc.closeStream(subscriptionId, closeCallback);
+      const token = wrpc.closeRequest(subscriptionId, closeCallback);
 
       if (token) {
         expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
@@ -1436,7 +1490,7 @@ describe.each<[StreamCommand, 'stream']>([
         throw ERROR_MESSAGE;
       });
 
-      const token = wrpc.closeStream(subscriptionId, closeCallback);
+      const token = wrpc.closeRequest(subscriptionId, closeCallback);
 
       if (token) {
         expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(undefined);
@@ -1456,7 +1510,7 @@ describe.each<[StreamCommand, 'stream']>([
     });
 
     test(`'${fn} + ${command}' should not send close stream message if no streams are present`, () => {
-      const token = wrpc.closeStream(
+      const token = wrpc.closeRequest(
         { token: 'random token', callback: callbackSpy },
         closeCallback,
       );
@@ -1471,7 +1525,7 @@ describe.each<[StreamCommand, 'stream']>([
     });
 
     test(`'${fn} + ${command}' should remove stream from closing map when EOF is received`, () => {
-      const token = wrpc.closeStream(subscriptionId, closeCallback);
+      const token = wrpc.closeRequest(subscriptionId, closeCallback);
       requestContext = { command: CLOSE };
 
       if (token) {
@@ -1510,7 +1564,7 @@ describe.each<[StreamCommand, 'stream']>([
     });
 
     test(`'${fn} + ${command}' should remove stream from closing map when any error is received`, () => {
-      const token = wrpc.closeStream(subscriptionId, closeCallback);
+      const token = wrpc.closeRequest(subscriptionId, closeCallback);
       requestContext = { command: CLOSE };
 
       if (token) {
@@ -1554,7 +1608,7 @@ describe.each<[StreamCommand, 'stream']>([
     });
 
     test(`'${fn} + ${command}' should reopen a stream if a stream with the same token is requested while closing`, () => {
-      const token = wrpc.closeStream(subscriptionId, closeCallback);
+      const token = wrpc.closeRequest(subscriptionId, closeCallback);
 
       expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
       const subscriptionIdNew = commandFn.call(wrpc, command, query, callbackSpyTwo);
@@ -1635,8 +1689,8 @@ describe.each<[StreamCommand, 'stream']>([
 
   describe('multiple streams', () => {
     test(`'${fn} + ${command}' should send close message`, () => {
-      const streams = [subscriptionId, subscriptionIdTwo];
-      const token = wrpc.closeStreams(streams, closeCallback);
+      const requests = [subscriptionId, subscriptionIdTwo];
+      const token = wrpc.closeRequests(requests, closeCallback);
       requestContext = { command: CLOSE };
 
       if (token) {
@@ -1678,8 +1732,8 @@ describe.each<[StreamCommand, 'stream']>([
         throw ERROR_MESSAGE;
       });
 
-      const streams = [subscriptionId, subscriptionIdTwo];
-      const token = wrpc.closeStreams(streams, closeCallback);
+      const requests = [subscriptionId, subscriptionIdTwo];
+      const token = wrpc.closeRequests(requests, closeCallback);
       requestContext = { command: CLOSE };
 
       if (token) {
@@ -1718,11 +1772,11 @@ describe.each<[StreamCommand, 'stream']>([
     });
 
     test(`'${fn} + ${command}' should not send close stream message if no streams are present`, () => {
-      const streams = [
+      const requests = [
         { token: 'random token', callback: callbackSpy },
         { token: 'another random token', callback: callbackSpyTwo },
       ];
-      const token = wrpc.closeStreams(streams, closeCallback);
+      const token = wrpc.closeRequests(requests, closeCallback);
       expect(token).toBeNull();
 
       expect(callbackSpy).not.toHaveBeenCalled();
@@ -1733,8 +1787,8 @@ describe.each<[StreamCommand, 'stream']>([
     });
 
     test(`'${fn} + ${command}' should remove stream from closing map when EOF is received`, () => {
-      const streams = [subscriptionId, subscriptionIdTwo];
-      const token = wrpc.closeStreams(streams, closeCallback);
+      const requests = [subscriptionId, subscriptionIdTwo];
+      const token = wrpc.closeRequests(requests, closeCallback);
       requestContext = { command: CLOSE };
 
       if (token) {
@@ -1779,8 +1833,8 @@ describe.each<[StreamCommand, 'stream']>([
     });
 
     test(`'${fn} + ${command}' should remove stream from closing map when any error is received`, () => {
-      const streams = [subscriptionId, subscriptionIdTwo];
-      const token = wrpc.closeStreams(streams, closeCallback);
+      const requests = [subscriptionId, subscriptionIdTwo];
+      const token = wrpc.closeRequests(requests, closeCallback);
       requestContext = { command: CLOSE };
 
       if (token) {
@@ -1830,8 +1884,8 @@ describe.each<[StreamCommand, 'stream']>([
     });
 
     test(`'${fn} + ${command}' should reopen a stream if a stream with the same token is requested while closing`, () => {
-      const streams = [subscriptionId, subscriptionIdTwo];
-      const token = wrpc.closeStreams(streams, closeCallback);
+      const requests = [subscriptionId, subscriptionIdTwo];
+      const token = wrpc.closeRequests(requests, closeCallback);
 
       expect(wrpc.streamInClosingState.get(subscriptionId.token)).toEqual(token);
       const subscriptionIdNew = commandFn.call(wrpc, command, query, callbackSpyTwo);

--- a/packages/cloudvision-connector/test/utils.spec.ts
+++ b/packages/cloudvision-connector/test/utils.spec.ts
@@ -59,7 +59,7 @@ import {
   Query,
   RequestContext,
   SearchOptions,
-  SubscriptionIdentifier,
+  RequestIdentifier,
 } from '../types';
 
 const EOF_STATUS: CloudVisionStatus = {
@@ -408,14 +408,14 @@ describe('createCloseParams', () => {
   let emitter: Emitter;
   const streamCallback = jest.fn();
   const streamToken = 'DodgerBlue';
-  const stream: SubscriptionIdentifier = {
+  const stream: RequestIdentifier = {
     token: streamToken,
     callback: streamCallback,
   };
   const requestContext: RequestContext = { command: SUBSCRIBE };
   const streamCallback2 = jest.fn();
   const streamToken2 = 'VinScully';
-  const stream2: SubscriptionIdentifier = {
+  const stream2: RequestIdentifier = {
     token: streamToken2,
     callback: streamCallback2,
   };
@@ -436,9 +436,9 @@ describe('createCloseParams', () => {
   });
 
   test('should create the proper stream close params for multiple streams', () => {
-    const streams = [stream, stream2];
+    const requests = [stream, stream2];
     const expectedCloseParams: CloseParams = { [streamToken]: true, [streamToken2]: true };
-    const closeParams = createCloseParams(streams, emitter);
+    const closeParams = createCloseParams(requests, emitter);
 
     expect(closeParams).toEqual(expectedCloseParams);
     expect(streamCallback).not.toHaveBeenCalled();
@@ -470,14 +470,14 @@ describe('createCloseParams', () => {
     () => {
       const anotherCallback = jest.fn();
       const expectedCloseParams: CloseParams = { [streamToken]: true };
-      const annotherStream: SubscriptionIdentifier = {
+      const annotherStream: RequestIdentifier = {
         token: streamToken,
         callback: anotherCallback,
       };
-      const streams = [stream, annotherStream];
+      const requests = [stream, annotherStream];
       emitter.bind(streamToken, requestContext, anotherCallback);
 
-      const closeParams = createCloseParams(streams, emitter);
+      const closeParams = createCloseParams(requests, emitter);
 
       expect(closeParams).toEqual(expectedCloseParams);
       expect(streamCallback).not.toHaveBeenCalled();

--- a/packages/cloudvision-connector/types/connection.ts
+++ b/packages/cloudvision-connector/types/connection.ts
@@ -19,7 +19,7 @@ export interface ConnectionCallback {
  * means we use the callback to identify the call, if there are multiple of
  * the same calls.
  */
-export interface SubscriptionIdentifier {
+export interface RequestIdentifier {
   callback: EventCallback;
   token: string;
 }


### PR DESCRIPTION
GET requests associated with a subscribe should be closed when the
subscribe is closed. The lack of this functionality caused a race
condition in the worker-based middleware when a subscription was closed
and re-opened before the associated GET request returned.

* Return SubscriptionIdentifier from callCommand.
* Return SubscriptionIdentifier instead of token from get and
getWithOptions.
* Create map from subscribe callbacks to GET SubscriptionIdentifier's
associated with them.
* Add logic to close GET's related to streams in closeStream and
closeStreams.
* Add logic to delete tokens from wrpc.activeRequests in
setStreamClosingState.
* Revise createCloseParams to remove repeated logic.
* Add handling to Connector.spec and Wrpc.spec for get/getWithOptions
returning a SubscriptionIdentifier instead of a simple token.