### PR TITLE
feat(cloudvision-connector): add instrumentation

### DIFF
--- a/packages/cloudvision-connector/src/Connector.ts
+++ b/packages/cloudvision-connector/src/Connector.ts
@@ -24,6 +24,7 @@ import {
   ACTIVE_CODE,
   APP_DATASET_TYPE,
   CLOSE,
+  DEFAULT_CONTEXT,
   DEVICES_DATASET_ID,
   DEVICE_DATASET_TYPE,
   GET,
@@ -42,6 +43,7 @@ import {
   makeToken,
   sanitizeOptions,
   sanitizeSearchOptions,
+  toBinaryKey,
   validateOptions,
   validateQuery,
 } from './utils';
@@ -177,7 +179,11 @@ export default class Connector extends Wrpc {
       if (status && status.code === ACTIVE_CODE) {
         this.getWithOptions(query, callback, sanitizedOptions);
       } else {
-        subscribeNotifCallback(err, result, status, token, { command: SUBSCRIBE });
+        subscribeNotifCallback(err, result, status, token, {
+          command: SUBSCRIBE,
+          token: token || DEFAULT_CONTEXT.token,
+          encodedParams: toBinaryKey(query),
+        });
       }
     };
 

--- a/packages/cloudvision-connector/src/constants.ts
+++ b/packages/cloudvision-connector/src/constants.ts
@@ -71,4 +71,8 @@ export const CONNECTED = 'connected';
 export const DISCONNECTED = 'disconnected';
 export const ID = 'cloudvision-connector';
 
-export const DEFAULT_CONTEXT: RequestContext = { command: 'NO_COMMAND' };
+export const DEFAULT_CONTEXT: RequestContext = {
+  command: 'NO_COMMAND',
+  token: 'NO_TOKEN',
+  encodedParams: 'NO_PARAMS',
+};

--- a/packages/cloudvision-connector/src/instrumentation.ts
+++ b/packages/cloudvision-connector/src/instrumentation.ts
@@ -1,0 +1,57 @@
+import { ContextCommand, RequestContext, WsCommand } from '../types';
+
+export interface InstrumentationConfig {
+  commands: WsCommand[];
+  start(context: RequestContext): void;
+  info(context: RequestContext): void;
+  end(context: RequestContext): void;
+}
+
+type Info = {
+  error?: string;
+  message?: string;
+};
+
+// Use empty function as a default placeholder
+/* istanbul ignore next */
+function emptyFunction(): void {} // eslint-disable-line @typescript-eslint/no-empty-function
+
+export default class Instrumentation {
+  private enableInstrumentation = false;
+
+  private instrumentedCommands: WsCommand[];
+
+  private startFunction: (context: RequestContext) => void;
+
+  private infoFunction: (context: RequestContext, info: Info) => void;
+
+  private endFunction: (context: RequestContext) => void;
+
+  constructor(config?: InstrumentationConfig) {
+    if (config) {
+      this.enableInstrumentation = true;
+    }
+    this.instrumentedCommands = config ? config.commands : [];
+    this.startFunction = config ? config.start : emptyFunction;
+    this.infoFunction = config ? config.info : emptyFunction;
+    this.endFunction = config ? config.end : emptyFunction;
+  }
+
+  public callStart(command: ContextCommand, context: RequestContext): void {
+    if (this.enableInstrumentation && this.instrumentedCommands.includes(command as WsCommand)) {
+      this.startFunction(context);
+    }
+  }
+
+  public callInfo(command: ContextCommand, context: RequestContext, info: Info): void {
+    if (this.enableInstrumentation && this.instrumentedCommands.includes(command as WsCommand)) {
+      this.infoFunction(context, info);
+    }
+  }
+
+  public callEnd(command: ContextCommand, context: RequestContext): void {
+    if (this.enableInstrumentation && this.instrumentedCommands.includes(command as WsCommand)) {
+      this.endFunction(context);
+    }
+  }
+}

--- a/packages/cloudvision-connector/test/emitter.spec.ts
+++ b/packages/cloudvision-connector/test/emitter.spec.ts
@@ -15,12 +15,17 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import { toBinaryKey } from '../src';
 import { DEFAULT_CONTEXT, GET } from '../src/constants';
 import Emitter from '../src/emitter';
 import { EventCallback, RequestContext } from '../types';
 
 describe('Emitter', () => {
-  const requestContext: RequestContext = { command: GET };
+  const requestContext: RequestContext = {
+    command: GET,
+    token: 'Best Team',
+    encodedParams: toBinaryKey('Dodgers'),
+  };
 
   test('should remove itself from callback during emit', () => {
     const emitter = new Emitter();

--- a/packages/cloudvision-connector/test/instrumentation.spec.ts
+++ b/packages/cloudvision-connector/test/instrumentation.spec.ts
@@ -1,0 +1,555 @@
+/* eslint-env jest */
+
+// Copyright (c) 2020, Arista Networks, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import Parser from '../src/Parser';
+import Wrpc from '../src/Wrpc';
+import {
+  ACTIVE_CODE,
+  EOF,
+  EOF_CODE,
+  GET,
+  GET_DATASETS,
+  PUBLISH,
+  SEARCH,
+  SEARCH_SUBSCRIBE,
+  SERVICE_REQUEST,
+  SUBSCRIBE,
+} from '../src/constants';
+import { toBinaryKey } from '../src/utils';
+import {
+  CloudVisionParams,
+  CloudVisionQueryMessage,
+  CloudVisionStatus,
+  NotifCallback,
+  QueryParams,
+  RequestContext,
+  StreamCommand,
+  WsCommand,
+} from '../types';
+
+jest.mock('../src/Parser', () => ({
+  parse: (res: string) => JSON.parse(res),
+  stringify: (msg: CloudVisionQueryMessage) => JSON.stringify(msg),
+}));
+
+jest.mock('../src/logger', () => {
+  return { log: jest.fn() };
+});
+
+type WrpcMethod = 'get' | 'pause' | 'publish' | 'requestService' | 'resume' | 'search';
+
+interface PolymorphicCommandFunction {
+  (command: WsCommand, params: CloudVisionParams, callback: NotifCallback): string;
+}
+
+interface CommandFunction {
+  (p: CloudVisionParams, cb: NotifCallback): string;
+}
+
+const query: QueryParams = { query: [] };
+
+function stringifyMessage(msg: object) {
+  return JSON.stringify(msg);
+}
+
+function createRequestContext(command: WsCommand, token: string, params: unknown): RequestContext {
+  return {
+    command,
+    token,
+    encodedParams: toBinaryKey(params),
+  };
+}
+
+describe.each<[WsCommand, WrpcMethod, boolean]>([
+  [GET, 'get', true],
+  [PUBLISH, 'publish', false],
+  [GET_DATASETS, 'get', true],
+  [SEARCH, 'search', false],
+  [SERVICE_REQUEST, 'requestService', false],
+])('Instrumented Call Commands', (command, fn, polymorphic) => {
+  let wrpc: Wrpc;
+  let ws: WebSocket;
+  let sendSpy: jest.SpyInstance;
+  let eventsEmitterSpy: jest.SpyInstance;
+  let eventsEmitterUnbindSpy: jest.SpyInstance;
+  let eventsEmitterBindSpy: jest.SpyInstance;
+  let polymorphicCommandFn: PolymorphicCommandFunction;
+  let commandFn: CommandFunction;
+  const startSpy = jest.fn();
+  const infoSpy = jest.fn();
+  const endSpy = jest.fn();
+  const callbackSpy = jest.fn();
+  const ERROR_MESSAGE = 'error';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    wrpc = new Wrpc({
+      batchResults: false,
+      debugMode: false,
+      pauseStreams: false,
+      instrumentationConfig: {
+        commands: [GET, PUBLISH, SEARCH, SERVICE_REQUEST, GET_DATASETS],
+        start: startSpy,
+        info: infoSpy,
+        end: endSpy,
+      },
+    });
+    // @ts-ignore
+    commandFn = wrpc[fn];
+    // @ts-ignore
+    polymorphicCommandFn = wrpc[fn];
+    wrpc.run('ws://localhost:8080');
+    ws = wrpc.websocket;
+    sendSpy = jest.spyOn(ws, 'send');
+    eventsEmitterSpy = jest.spyOn(wrpc.eventsEmitter, 'emit');
+    eventsEmitterBindSpy = jest.spyOn(wrpc.eventsEmitter, 'bind');
+    eventsEmitterUnbindSpy = jest.spyOn(wrpc.eventsEmitter, 'unbind');
+  });
+
+  afterEach(() => {
+    sendSpy.mockClear();
+    eventsEmitterSpy.mockClear();
+    eventsEmitterBindSpy.mockClear();
+    eventsEmitterUnbindSpy.mockClear();
+    callbackSpy.mockClear();
+    startSpy.mockClear();
+    infoSpy.mockClear();
+    endSpy.mockClear();
+  });
+
+  test(`'${fn} + ${command}' should not send instrumentation message start if socket is not running`, () => {
+    let token;
+    if (polymorphic) {
+      token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
+    } else {
+      token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+
+    expect(callbackSpy).toHaveBeenCalledWith('Connection is down');
+    expect(eventsEmitterSpy).not.toHaveBeenCalled();
+    expect(eventsEmitterBindSpy).not.toHaveBeenCalled();
+    expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
+    expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
+    expect(token).toBe(null);
+  });
+
+  test(`'${fn} + ${command}' should send instrumentation message start if socket is running`, () => {
+    ws.dispatchEvent(new MessageEvent('open', {}));
+
+    let token;
+    if (polymorphic) {
+      token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
+    } else {
+      token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token) {
+      const requestContext = createRequestContext(command, token, {});
+      expect(callbackSpy).not.toHaveBeenCalled();
+      expect(eventsEmitterSpy).not.toHaveBeenCalled();
+      expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
+      expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      expect(sendSpy).toHaveBeenCalledWith(
+        Parser.stringify({
+          token,
+          command,
+          params: {},
+        }),
+      );
+      expect(token).not.toBeNull();
+      expect(startSpy).toHaveBeenCalledWith(requestContext);
+      expect(infoSpy).not.toHaveBeenCalled();
+      expect(endSpy).not.toHaveBeenCalled();
+    }
+    expect(token).not.toBeNull();
+  });
+
+  test(`'${fn} + ${command}' should send instrumentation info message on error`, () => {
+    ws.dispatchEvent(new MessageEvent('open', {}));
+    sendSpy.mockImplementation(() => {
+      throw ERROR_MESSAGE;
+    });
+
+    let token;
+    if (polymorphic) {
+      token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
+    } else {
+      token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token) {
+      const requestContext = createRequestContext(command, token, {});
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      expect(sendSpy).toHaveBeenCalledWith(
+        Parser.stringify({
+          token,
+          command,
+          params: {},
+        }),
+      );
+      expect(callbackSpy).toHaveBeenCalledTimes(1);
+      expect(callbackSpy).toHaveBeenCalledWith(
+        ERROR_MESSAGE,
+        undefined,
+        undefined,
+        token,
+        requestContext,
+      );
+      expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
+      expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
+      expect(token).not.toBeNull();
+      expect(startSpy).toHaveBeenCalledWith(requestContext);
+      expect(infoSpy).toHaveBeenCalledWith(requestContext, { error: ERROR_MESSAGE });
+      expect(endSpy).toHaveBeenCalledWith(requestContext);
+    }
+    expect(token).not.toBeNull();
+  });
+
+  test(`'${fn} + ${command}' should send instrumentation end message on EOF`, () => {
+    const EOF_STATUS: CloudVisionStatus = { code: EOF_CODE };
+    ws.dispatchEvent(new MessageEvent('open', {}));
+
+    let token;
+    if (polymorphic) {
+      token = polymorphicCommandFn.call(wrpc, command, {}, callbackSpy);
+    } else {
+      token = commandFn.call(wrpc, {}, callbackSpy);
+    }
+    if (token) {
+      const requestContext = createRequestContext(command, token, {});
+      ws.dispatchEvent(
+        new MessageEvent('message', {
+          data: stringifyMessage({ token, error: EOF, status: EOF_STATUS }),
+        }),
+      );
+
+      expect(callbackSpy).toHaveBeenCalledTimes(1);
+      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestContext);
+      expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterSpy).toHaveBeenCalledWith(token, EOF, undefined, EOF_STATUS);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
+      expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      expect(token).not.toBeNull();
+      expect(startSpy).toHaveBeenCalledWith(requestContext);
+      expect(infoSpy).toHaveBeenCalledWith(requestContext, { error: EOF });
+      expect(endSpy).toHaveBeenCalledWith(requestContext);
+    }
+    expect(token).not.toBeNull();
+  });
+});
+
+describe.each<[StreamCommand, 'stream']>([
+  [SUBSCRIBE, 'stream'],
+  [SEARCH_SUBSCRIBE, 'stream'],
+  [SERVICE_REQUEST, 'stream'],
+])('Instrumented Stream Commands', (command, fn) => {
+  let wrpc: Wrpc;
+  let ws: WebSocket;
+  let sendSpy: jest.SpyInstance;
+  let eventsEmitterSpy: jest.SpyInstance;
+  let eventsEmitterUnbindSpy: jest.SpyInstance;
+  let eventsEmitterBindSpy: jest.SpyInstance;
+  let commandFn: Wrpc['stream'];
+  const callbackSpy = jest.fn();
+  const startSpy = jest.fn();
+  const infoSpy = jest.fn();
+  const endSpy = jest.fn();
+  const ACTIVE_STATUS: CloudVisionStatus = { code: ACTIVE_CODE };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    wrpc = new Wrpc({
+      batchResults: false,
+      debugMode: false,
+      pauseStreams: false,
+      instrumentationConfig: {
+        commands: [SUBSCRIBE, SERVICE_REQUEST, SEARCH_SUBSCRIBE],
+        start: startSpy,
+        info: infoSpy,
+        end: endSpy,
+      },
+    });
+    commandFn = wrpc[fn];
+    wrpc.run('ws://localhost:8080');
+    ws = wrpc.websocket;
+    sendSpy = jest.spyOn(ws, 'send');
+    eventsEmitterSpy = jest.spyOn(wrpc.eventsEmitter, 'emit');
+    eventsEmitterBindSpy = jest.spyOn(wrpc.eventsEmitter, 'bind');
+    eventsEmitterUnbindSpy = jest.spyOn(wrpc.eventsEmitter, 'unbind');
+  });
+
+  afterEach(() => {
+    sendSpy.mockClear();
+    eventsEmitterSpy.mockClear();
+    eventsEmitterBindSpy.mockClear();
+    eventsEmitterUnbindSpy.mockClear();
+    callbackSpy.mockClear();
+    startSpy.mockClear();
+    infoSpy.mockClear();
+    endSpy.mockClear();
+  });
+
+  test(`'${fn} + ${command}' should not send instrumentation info message if socket is not running`, () => {
+    const subscriptionId = commandFn.call(wrpc, command, query, callbackSpy);
+
+    expect(callbackSpy).toHaveBeenCalledWith('Connection is down');
+    expect(eventsEmitterSpy).not.toHaveBeenCalled();
+    expect(eventsEmitterBindSpy).not.toHaveBeenCalled();
+    expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
+    expect(subscriptionId).toBe(null);
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
+  });
+
+  test(`'${fn} + ${command}' should send instrumentation info message if socket is running`, () => {
+    ws.dispatchEvent(new MessageEvent('open', {}));
+
+    const subscriptionId = commandFn.call(wrpc, command, query, callbackSpy);
+    if (subscriptionId && subscriptionId.token) {
+      const token = subscriptionId.token;
+      const requestContext = createRequestContext(command, token, query);
+      expect(wrpc.streams).not.toContain(token);
+      expect(callbackSpy).not.toHaveBeenCalled();
+      expect(eventsEmitterSpy).not.toHaveBeenCalled();
+      expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
+      expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      expect(sendSpy).toHaveBeenCalledWith(
+        Parser.stringify({
+          token,
+          command,
+          params: query,
+        }),
+      );
+      expect(subscriptionId).not.toBeNull();
+      expect(startSpy).toHaveBeenCalledWith(requestContext);
+      expect(infoSpy).not.toHaveBeenCalled();
+      expect(endSpy).not.toHaveBeenCalled();
+    }
+    expect(subscriptionId).not.toBeNull();
+  });
+
+  test(`'${fn} + ${command}' should send instrumentation end message on EOF`, () => {
+    const EOF_STATUS: CloudVisionStatus = { code: EOF_CODE };
+    ws.dispatchEvent(new MessageEvent('open', {}));
+
+    const subscriptionId = commandFn.call(wrpc, command, query, callbackSpy);
+    if (subscriptionId && subscriptionId.token) {
+      const token = subscriptionId.token;
+      const requestContext = createRequestContext(command, token, query);
+      ws.dispatchEvent(
+        new MessageEvent('message', {
+          data: stringifyMessage({ token, error: EOF, status: EOF_STATUS }),
+        }),
+      );
+
+      expect(callbackSpy).toHaveBeenCalledTimes(1);
+      expect(callbackSpy).toHaveBeenCalledWith(EOF, undefined, EOF_STATUS, token, requestContext);
+      expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterSpy).toHaveBeenCalledWith(token, EOF, undefined, EOF_STATUS);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
+      expect(eventsEmitterUnbindSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterUnbindSpy).toHaveBeenCalledWith(token, expect.any(Function));
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      expect(token).not.toBeNull();
+      expect(startSpy).toHaveBeenCalledWith(requestContext);
+      expect(infoSpy).toHaveBeenCalledWith(requestContext, { error: EOF });
+      expect(endSpy).toHaveBeenCalledWith(requestContext);
+    }
+    expect(subscriptionId).not.toBeNull();
+  });
+
+  test(`'${fn} + ${command}' should send instrumentation message if ACK message is received`, () => {
+    ws.dispatchEvent(new MessageEvent('open', {}));
+
+    const subscriptionId = commandFn.call(wrpc, command, query, callbackSpy);
+    if (subscriptionId && subscriptionId.token) {
+      const token = subscriptionId.token;
+      const requestContext = createRequestContext(command, token, query);
+      ws.dispatchEvent(
+        new MessageEvent('message', {
+          data: stringifyMessage({ token, status: ACTIVE_STATUS }),
+        }),
+      );
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      expect(sendSpy).toHaveBeenCalledWith(
+        Parser.stringify({
+          token,
+          command,
+          params: query,
+        }),
+      );
+      expect(wrpc.streams).toContain(token);
+      expect(callbackSpy).toHaveBeenCalledTimes(1);
+      expect(callbackSpy).toHaveBeenCalledWith(
+        null,
+        undefined,
+        ACTIVE_STATUS,
+        token,
+        requestContext,
+      );
+      expect(eventsEmitterSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterSpy).toHaveBeenCalledWith(token, null, undefined, ACTIVE_STATUS);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
+      expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
+      expect(token).not.toBeNull();
+      expect(startSpy).toHaveBeenCalledWith(requestContext);
+      expect(infoSpy).toHaveBeenCalledWith(requestContext, { message: 'stream active' });
+      expect(endSpy).not.toHaveBeenCalled();
+    }
+    expect(subscriptionId).not.toBeNull();
+  });
+});
+
+describe.each<[WsCommand, 'stream' | 'get']>([
+  [GET, 'get'],
+  [SUBSCRIBE, 'stream'],
+  [SEARCH_SUBSCRIBE, 'stream'],
+  [SERVICE_REQUEST, 'stream'],
+])('Non Instrumented Commands', (command, fn) => {
+  let wrpc: Wrpc;
+  let ws: WebSocket;
+  let sendSpy: jest.SpyInstance;
+  let eventsEmitterSpy: jest.SpyInstance;
+  let eventsEmitterUnbindSpy: jest.SpyInstance;
+  let eventsEmitterBindSpy: jest.SpyInstance;
+  let commandFn: Wrpc['stream'];
+  const callbackSpy = jest.fn();
+  const startSpy = jest.fn();
+  const infoSpy = jest.fn();
+  const endSpy = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    wrpc = new Wrpc({
+      batchResults: false,
+      debugMode: false,
+      pauseStreams: false,
+      instrumentationConfig: {
+        commands: [PUBLISH],
+        start: startSpy,
+        info: infoSpy,
+        end: endSpy,
+      },
+    });
+    // @ts-ignore
+    commandFn = wrpc[fn];
+    wrpc.run('ws://localhost:8080');
+    ws = wrpc.websocket;
+    sendSpy = jest.spyOn(ws, 'send');
+    eventsEmitterSpy = jest.spyOn(wrpc.eventsEmitter, 'emit');
+    eventsEmitterBindSpy = jest.spyOn(wrpc.eventsEmitter, 'bind');
+    eventsEmitterUnbindSpy = jest.spyOn(wrpc.eventsEmitter, 'unbind');
+  });
+
+  afterEach(() => {
+    sendSpy.mockClear();
+    eventsEmitterSpy.mockClear();
+    eventsEmitterBindSpy.mockClear();
+    eventsEmitterUnbindSpy.mockClear();
+    callbackSpy.mockClear();
+    startSpy.mockClear();
+    infoSpy.mockClear();
+    endSpy.mockClear();
+  });
+
+  test(`'${fn} + ${command}' should not send instrumentation info message if socket is not running`, () => {
+    // @ts-ignore
+    const subscriptionId = commandFn.call(wrpc, command, query, callbackSpy);
+
+    expect(callbackSpy).toHaveBeenCalledWith('Connection is down');
+    expect(eventsEmitterSpy).not.toHaveBeenCalled();
+    expect(eventsEmitterBindSpy).not.toHaveBeenCalled();
+    expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
+    expect(subscriptionId).toBe(null);
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
+  });
+
+  test(`'${fn} + ${command}' should send instrumentation message if socket is running, but command is not instrumented`, () => {
+    ws.dispatchEvent(new MessageEvent('open', {}));
+
+    // @ts-ignore
+    const subscriptionId = commandFn.call(wrpc, command, query, callbackSpy);
+    if (subscriptionId && subscriptionId.token) {
+      const token = subscriptionId.token;
+      const requestContext = createRequestContext(command, token, query);
+      expect(wrpc.streams).not.toContain(token);
+      expect(callbackSpy).not.toHaveBeenCalled();
+      expect(eventsEmitterSpy).not.toHaveBeenCalled();
+      expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
+      expect(eventsEmitterBindSpy).toHaveBeenCalledTimes(1);
+      expect(eventsEmitterBindSpy).toHaveBeenCalledWith(
+        token,
+        requestContext,
+        expect.any(Function),
+      );
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      expect(sendSpy).toHaveBeenCalledWith(
+        Parser.stringify({
+          token,
+          command,
+          params: query,
+        }),
+      );
+      expect(subscriptionId).not.toBeNull();
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(infoSpy).not.toHaveBeenCalled();
+      expect(endSpy).not.toHaveBeenCalled();
+    }
+    expect(subscriptionId).not.toBeNull();
+  });
+});

--- a/packages/cloudvision-connector/types/connection.ts
+++ b/packages/cloudvision-connector/types/connection.ts
@@ -5,8 +5,12 @@ export interface EventCallback {
   (requestContext: RequestContext, ...args: any[]): void;
 }
 
+export type ContextCommand = WsCommand | 'connection' | 'NO_COMMAND';
+
 export interface RequestContext {
-  command: WsCommand | 'connection' | 'NO_COMMAND';
+  command: ContextCommand;
+  encodedParams: string;
+  token: string;
 }
 
 export interface ConnectionCallback {


### PR DESCRIPTION
Add instrumentation for all WebSocket calls. This allows the user of
the library to hook in their own instrumentation, so that they could
for example trace the timing and frequency of calls on the WebSocket.