### PR TITLE
fix(cloudvision-connector): add getAndSubscribe to Conenctor

### DIFF
--- a/packages/cloudvision-connector/src/Connector.ts
+++ b/packages/cloudvision-connector/src/Connector.ts
@@ -57,6 +57,8 @@ export default class Connector extends Wrpc {
 
   public static GET: typeof GET = GET;
 
+  public static GET_AND_SUBSCRIBE: typeof GET_AND_SUBSCRIBE = GET_AND_SUBSCRIBE;
+
   public static ID: typeof ID = ID;
 
   public static PAUSE: typeof PAUSE = PAUSE;


### PR DESCRIPTION
Add the get and subscribe command to the Connector class for library
users to reference