### PR TITLE
fix(cloudvision-connector): export needed constants and types

### DIFF
--- a/packages/cloudvision-connector/src/index.ts
+++ b/packages/cloudvision-connector/src/index.ts
@@ -32,5 +32,14 @@ export {
 
 export { default } from './Connector';
 export { default as Parser } from './Parser';
-export { ACTIVE_CODE, CONNECTED, DISCONNECTED, EOF_CODE } from './constants';
+export {
+  ACTIVE_CODE,
+  APP_DATASET_TYPE,
+  CONNECTED,
+  DEVICE_DATASET_TYPE,
+  DISCONNECTED,
+  EOF,
+  EOF_CODE,
+  GET_REQUEST_COMPLETED,
+} from './constants';
 export { fromBinaryKey, hashObject, toBinaryKey, sanitizeOptions } from './utils';

--- a/packages/cloudvision-connector/types/notifications.ts
+++ b/packages/cloudvision-connector/types/notifications.ts
@@ -9,7 +9,7 @@ export interface CloudVisionDatasets {
 }
 
 export interface CloudVisionStatus {
-  code: number;
+  code?: number;
 
   message?: string;
 }


### PR DESCRIPTION
Export some more constants that are handy.
Update CloudVisionStatus type to be what it actually is on the wire.