### PR TITLE
feat(cloudvision-connector): Remove deduping, other unused functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1828,23 +1828,29 @@
       }
     },
     "compare-func": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
-      "integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
+      "version": "2.0.0",
+      "resolved": "https://npm.corp.arista.io/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
-        "dot-prop": "^3.0.0"
+        "dot-prop": "^5.1.0"
       },
       "dependencies": {
         "dot-prop": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+          "version": "5.2.0",
+          "resolved": "https://npm.corp.arista.io/dot-prop/-/dot-prop-5.2.0.tgz",
+          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
           "dev": true,
           "requires": {
-            "is-obj": "^1.0.0"
+            "is-obj": "^2.0.0"
           }
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://npm.corp.arista.io/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+          "dev": true
         }
       }
     },
@@ -1889,13 +1895,40 @@
       "dev": true
     },
     "conventional-changelog-angular": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz",
-      "integrity": "sha512-k7RPPRs0vp8+BtPsM9uDxRl6KcgqtCJmzRD1wRtgqmhQ96g8ifBGo9O/TZBG23jqlXS/rg8BKRDELxfnQQGiaA==",
+      "version": "5.0.11",
+      "resolved": "https://npm.corp.arista.io/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
+      "integrity": "sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "q": "^1.5.1"
+      },
+      "dependencies": {
+        "compare-func": {
+          "version": "2.0.0",
+          "resolved": "https://npm.corp.arista.io/compare-func/-/compare-func-2.0.0.tgz",
+          "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+          "dev": true,
+          "requires": {
+            "array-ify": "^1.0.0",
+            "dot-prop": "^5.1.0"
+          }
+        },
+        "dot-prop": {
+          "version": "5.2.0",
+          "resolved": "https://npm.corp.arista.io/dot-prop/-/dot-prop-5.2.0.tgz",
+          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://npm.corp.arista.io/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+          "dev": true
+        }
       }
     },
     "conventional-changelog-core": {
@@ -1938,12 +1971,12 @@
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.16.tgz",
-      "integrity": "sha512-jmU1sDJDZpm/dkuFxBeRXvyNcJQeKhGtVcFFkwTphUAzyYWcwz2j36Wcv+Mv2hU3tpvLMkysOPXJTLO55AUrYQ==",
+      "version": "4.0.17",
+      "resolved": "https://npm.corp.arista.io/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
+      "integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "conventional-commits-filter": "^2.0.6",
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.6",
@@ -6458,9 +6491,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.10.1",
+      "resolved": "https://npm.corp.arista.io/uglify-js/-/uglify-js-3.10.1.tgz",
+      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
       "dev": true,
       "optional": true
     },

--- a/packages/cloudvision-connector/package-lock.json
+++ b/packages/cloudvision-connector/package-lock.json
@@ -1324,6 +1324,12 @@
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
 			"dev": true
 		},
+		"@types/uuid": {
+			"version": "8.0.1",
+			"resolved": "https://npm.corp.arista.io/@types%2fuuid/-/uuid-8.0.1.tgz",
+			"integrity": "sha512-2kE8rEFgJpbBAPw5JghccEevQb0XVU0tewF/8h7wPQTeCtoJ6h8qmBIwuzUVm2MutmzC/cpCkwxudixoNYDp1A==",
+			"dev": true
+		},
 		"@types/yargs": {
 			"version": "15.0.5",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
@@ -3592,7 +3598,8 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -7681,9 +7688,7 @@
 		"uuid": {
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-			"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
-			"dev": true,
-			"optional": true
+			"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
 		},
 		"v8-compile-cache": {
 			"version": "2.1.1",

--- a/packages/cloudvision-connector/package.json
+++ b/packages/cloudvision-connector/package.json
@@ -52,8 +52,8 @@
   "dependencies": {
     "a-msgpack": "4.5.3",
     "base64-js": "1.3.1",
-    "imurmurhash": "0.1.4",
-    "jsbi": "3.1.2"
+    "jsbi": "3.1.2",
+    "uuid": "8.3.0"
   },
   "devDependencies": {
     "@arista/prettier-config": "1.1.3",
@@ -65,6 +65,7 @@
     "@types/imurmurhash": "0.1.1",
     "@types/jest": "25.2.3",
     "@types/js-yaml": "3.12.4",
+    "@types/uuid": "8.0.1",
     "cross-env": "7.0.2",
     "eslint": "6.8.0",
     "eslint-config-airbnb-base": "14.1.0",

--- a/packages/cloudvision-connector/rollup.config.js
+++ b/packages/cloudvision-connector/rollup.config.js
@@ -21,7 +21,7 @@ const external = Object.keys(packageJson.dependencies);
 const globals = {
   'a-msgpack': 'msgpack',
   'base64-js': 'base64-js',
-  'imurmurhash': 'MurmurHash3',
+  'uuid': 'uuid',
   'jsbi': 'JSBI',
 };
 

--- a/packages/cloudvision-connector/src/Connector.ts
+++ b/packages/cloudvision-connector/src/Connector.ts
@@ -1,6 +1,5 @@
 import {
   AppParams,
-  CloudVisionParams,
   DatasetType,
   NotifCallback,
   Options,
@@ -12,7 +11,6 @@ import {
   SearchParams,
   ServiceRequest,
   SubscriptionIdentifier,
-  WsCommand,
 } from '../types';
 
 import Wrpc from './Wrpc';
@@ -25,7 +23,6 @@ import {
   GET_AND_SUBSCRIBE,
   GET_DATASETS,
   ID,
-  PAUSE,
   PUBLISH,
   SEARCH,
   SEARCH_SUBSCRIBE,
@@ -35,7 +32,6 @@ import {
 import {
   makeNotifCallback,
   makePublishCallback,
-  makeToken,
   sanitizeOptions,
   sanitizeSearchOptions,
   validateOptions,
@@ -60,8 +56,6 @@ export default class Connector extends Wrpc {
   public static GET_AND_SUBSCRIBE: typeof GET_AND_SUBSCRIBE = GET_AND_SUBSCRIBE;
 
   public static ID: typeof ID = ID;
-
-  public static PAUSE: typeof PAUSE = PAUSE;
 
   public static PUBLISH: typeof PUBLISH = PUBLISH;
 
@@ -191,13 +185,6 @@ export default class Connector extends Wrpc {
   public getDevices(callback: NotifCallback): string | null {
     const deviceType: typeof DEVICE_DATASET_TYPE[] = [DEVICE_DATASET_TYPE];
     return this.get(GET_DATASETS, { types: deviceType }, makeNotifCallback(callback));
-  }
-
-  /**
-   * Generates the unique token that the request can be referenced by.
-   */
-  public getCommandToken(command: WsCommand, params: CloudVisionParams): string {
-    return makeToken(command, params);
   }
 
   /**

--- a/packages/cloudvision-connector/src/constants.ts
+++ b/packages/cloudvision-connector/src/constants.ts
@@ -34,11 +34,6 @@ export const EOF_CODE = 1001;
 export const ACTIVE_CODE = 3001;
 
 /**
- * Status code for Paused (when the incoming results for a request have been paused).
- */
-export const PAUSED_CODE = 1002;
-
-/**
  * Error status sent when a request has finished streaming data.
  */
 export const RESPONSE_COMPLETED = 'RESPONSE_COMPLETED';
@@ -50,9 +45,7 @@ export const DEVICES_DATASET_ID = 'DEVICES_DATASET_ID';
 export const GET = 'get';
 export const GET_DATASETS = 'getDatasets';
 export const GET_AND_SUBSCRIBE = 'getAndSubscribe';
-export const PAUSE = 'pause';
 export const PUBLISH = 'publish';
-export const RESUME = 'resume';
 export const SUBSCRIBE = 'subscribe';
 export const SEARCH = 'alpha/search';
 export const SEARCH_SUBSCRIBE = 'alpha/searchSubscribe';

--- a/packages/cloudvision-connector/src/index.ts
+++ b/packages/cloudvision-connector/src/index.ts
@@ -42,4 +42,4 @@ export {
   EOF_CODE,
   GET_REQUEST_COMPLETED,
 } from './constants';
-export { fromBinaryKey, hashObject, toBinaryKey, sanitizeOptions } from './utils';
+export { fromBinaryKey, toBinaryKey, sanitizeOptions } from './utils';

--- a/packages/cloudvision-connector/src/utils.ts
+++ b/packages/cloudvision-connector/src/utils.ts
@@ -17,7 +17,6 @@
 
 import { encode, decode, Codec } from 'a-msgpack';
 import { fromByteArray, toByteArray } from 'base64-js';
-import MurmurHash3 from 'imurmurhash';
 
 import {
   CloseParams,
@@ -25,8 +24,6 @@ import {
   CloudVisionBatchedResult,
   CloudVisionDatasets,
   CloudVisionNotifs,
-  CloudVisionParams,
-  CloudVisionPublishRequest,
   CloudVisionResult,
   CloudVisionServiceResult,
   CloudVisionStatus,
@@ -37,9 +34,7 @@ import {
   RequestContext,
   SearchOptions,
   SearchType,
-  ServiceRequest,
   SubscriptionIdentifier,
-  WsCommand,
 } from '../types';
 
 import { ALL_SEARCH_TYPES, EOF_CODE, ERROR, SEARCH_TYPE_ANY } from './constants';
@@ -55,15 +50,6 @@ export interface ExplicitOptions extends Options {
   start: number | undefined;
 
   versions?: number;
-}
-
-/**
- * Definition for an instance of MurmurHash3, rather than the module.
- */
-interface MurmurHash {
-  hash(value: string): MurmurHash;
-  reset(seed?: number): MurmurHash;
-  result(): number;
 }
 
 /**
@@ -155,47 +141,6 @@ export function validateQuery(query: Query, callback: NotifCallback, allowEmpty 
   }
 
   return true;
-}
-
-/**
- * Recursively hashes an object, given an object and a hashState.
- */
-function hashObjectHelper<T extends {}>(object: T, hashState: MurmurHash): string {
-  const objKeys = Object.keys(object) as (keyof T)[];
-  for (let i = 0; i < objKeys.length; i += 1) {
-    const key = objKeys[i];
-    const value = object[key];
-    if (value && typeof value === 'object') {
-      hashState.hash(key.toString()).hash(hashObjectHelper(value, hashState));
-    } else {
-      hashState.hash(key + '' + value);
-    }
-  }
-
-  return hashState.result().toString();
-}
-
-/**
- * Creates a unique hash given an object.
- */
-export function hashObject(object: {}): string {
-  const hashState = MurmurHash3();
-  return hashObjectHelper(object, hashState);
-}
-
-/**
- * Generates token based on the [[WsCommand]] and params ([[CloudVisionParams]],
- * [[CloudVisionPublishRequest]], [[ServiceRequest]]) of a request. This is
- * used to map requests to responses when dispatching response callbacks.
- */
-export function makeToken(
-  command: WsCommand,
-  params: CloudVisionParams | CloudVisionPublishRequest | ServiceRequest,
-): string {
-  return hashObject({
-    command,
-    params,
-  });
 }
 
 /**

--- a/packages/cloudvision-connector/test/Connector.spec.ts
+++ b/packages/cloudvision-connector/test/Connector.spec.ts
@@ -31,9 +31,8 @@ import {
   SERVICE_REQUEST,
   SUBSCRIBE,
 } from '../src/constants';
-import { makeToken, sanitizeOptions, sanitizeSearchOptions, toBinaryKey } from '../src/utils';
+import { sanitizeOptions, sanitizeSearchOptions, toBinaryKey } from '../src/utils';
 import {
-  CloudVisionParams,
   CloudVisionStatus,
   NotifCallback,
   Options,
@@ -90,18 +89,6 @@ const ERROR_STATUS: CloudVisionStatus = {
 };
 
 jest.spyOn(console, 'groupCollapsed').mockImplementation();
-
-describe('getCommandToken', () => {
-  test('should return the proper token', () => {
-    const conn = new Connector();
-    const command = GET;
-    const params: CloudVisionParams = {
-      hello: true,
-    };
-
-    expect(conn.getCommandToken(command, params)).toEqual(makeToken(command, params));
-  });
-});
 
 describe('closeSubscriptions', () => {
   const streamCallback = jest.fn();
@@ -186,7 +173,7 @@ describe('runStreamingService', () => {
 
     const streamIdentifier = conn.runStreamingService(request, spyCallback);
     if (streamIdentifier !== null) {
-      expect(streamIdentifier.token).toBe('582204119');
+      expect(streamIdentifier.token).toEqual(expect.any(String));
       expect(typeof streamIdentifier.callback).toBe('function');
     }
     expect(conn.runStreamingService).toHaveBeenCalledTimes(1);

--- a/packages/cloudvision-connector/test/instrumentation.spec.ts
+++ b/packages/cloudvision-connector/test/instrumentation.spec.ts
@@ -52,7 +52,7 @@ jest.mock('../src/logger', () => {
   return { log: jest.fn() };
 });
 
-type WrpcMethod = 'get' | 'pause' | 'publish' | 'requestService' | 'resume' | 'search';
+type WrpcMethod = 'get' | 'publish' | 'requestService' | 'search';
 
 interface PolymorphicCommandFunction {
   (command: WsCommand, params: CloudVisionParams, callback: NotifCallback): string;
@@ -102,7 +102,6 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     wrpc = new Wrpc({
       batchResults: false,
       debugMode: false,
-      pauseStreams: false,
       instrumentationConfig: {
         commands: [GET, PUBLISH, SEARCH, SERVICE_REQUEST, GET_DATASETS],
         start: startSpy,
@@ -297,7 +296,6 @@ describe.each<[StreamCommand, 'stream']>([
     wrpc = new Wrpc({
       batchResults: false,
       debugMode: false,
-      pauseStreams: false,
       instrumentationConfig: {
         commands: [SUBSCRIBE, SERVICE_REQUEST, SEARCH_SUBSCRIBE],
         start: startSpy,
@@ -345,7 +343,6 @@ describe.each<[StreamCommand, 'stream']>([
     if (subscriptionId && subscriptionId.token) {
       const token = subscriptionId.token;
       const requestContext = createRequestContext(command, token, query);
-      expect(wrpc.streams).not.toContain(token);
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();
@@ -426,7 +423,6 @@ describe.each<[StreamCommand, 'stream']>([
           params: query,
         }),
       );
-      expect(wrpc.streams).toContain(token);
       expect(callbackSpy).toHaveBeenCalledTimes(1);
       expect(callbackSpy).toHaveBeenCalledWith(
         null,
@@ -476,7 +472,6 @@ describe.each<[WsCommand, 'stream' | 'get']>([
     wrpc = new Wrpc({
       batchResults: false,
       debugMode: false,
-      pauseStreams: false,
       instrumentationConfig: {
         commands: [PUBLISH],
         start: startSpy,
@@ -527,7 +522,6 @@ describe.each<[WsCommand, 'stream' | 'get']>([
     if (subscriptionId && subscriptionId.token) {
       const token = subscriptionId.token;
       const requestContext = createRequestContext(command, token, query);
-      expect(wrpc.streams).not.toContain(token);
       expect(callbackSpy).not.toHaveBeenCalled();
       expect(eventsEmitterSpy).not.toHaveBeenCalled();
       expect(eventsEmitterUnbindSpy).not.toHaveBeenCalled();

--- a/packages/cloudvision-connector/test/utils.spec.ts
+++ b/packages/cloudvision-connector/test/utils.spec.ts
@@ -35,13 +35,11 @@ import Emitter from '../src/emitter';
 import { log } from '../src/logger';
 import {
   createCloseParams,
-  hashObject,
   invalidParamMsg,
   isMicroSeconds,
   isValidArg,
   makeNotifCallback,
   makePublishCallback,
-  makeToken,
   sanitizeOptions,
   sanitizeSearchOptions,
   toBinaryKey,
@@ -53,7 +51,6 @@ import {
   CloseParams,
   CloudVisionDatasets,
   CloudVisionNotifs,
-  CloudVisionParams,
   CloudVisionServiceResult,
   CloudVisionStatus,
   Options,
@@ -269,55 +266,6 @@ describe('validateQuery', () => {
     // @ts-ignore explicity testings an invalid input
     expect(validateQuery(query, spyCallback)).toBe(false);
     expect(spyCallback).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('hashObject', () => {
-  test('should return equal hashes for equal objects', () => {
-    const creators = [
-      () => ({ a: 1, b: 2, c: 'test' }),
-      () => ({ a: { b: { c: { d: 1, e: 'hello' }, f: 89 } } }),
-    ];
-    creators.forEach((creator) => {
-      expect(hashObject(creator())).toEqual(hashObject(creator()));
-    });
-  });
-
-  test('should return different hashes for different simple objects', () => {
-    expect(hashObject({ a: 'silver' })).not.toEqual(hashObject({ a: 'gold' }));
-    expect(hashObject({ a: 'silver' })).not.toEqual(hashObject({ b: 'silver' }));
-    expect(hashObject({ a: 1, b: 2 })).not.toEqual(hashObject({ a: 2, b: 1 }));
-  });
-
-  test('should return different hashes for different deep objects', () => {
-    expect(hashObject({ a: { b: 'c' } })).not.toEqual(hashObject({ a: { d: 'e' } }));
-    expect(hashObject({ a: { b: 'c' } })).not.toEqual(hashObject({ a: { b: 7 } }));
-    expect(hashObject({ a: { b: 'c' } })).not.toEqual(hashObject({ a: { c: 'b' } }));
-    expect(hashObject({ a: { b: [1, 2, 3] } })).not.toEqual(hashObject({ a: { b: [1, 23] } }));
-  });
-
-  test('should return different hashes for deep objects differing only in top-level key', () => {
-    const apples = { apples: { count: 5 } };
-    const oranges = { oranges: { count: 5 } };
-
-    expect(hashObject(apples)).not.toEqual(hashObject(oranges));
-  });
-});
-
-describe('makeToken', () => {
-  test('should make token using hashObject', () => {
-    const command = GET;
-    const params: CloudVisionParams = {
-      hello: true,
-    };
-    const expectedToken = hashObject({
-      command,
-      params,
-    });
-
-    const token = makeToken(command, params);
-
-    expect(token).toBe(expectedToken);
   });
 });
 

--- a/packages/cloudvision-connector/types/params.ts
+++ b/packages/cloudvision-connector/types/params.ts
@@ -7,9 +7,7 @@ import {
   GET,
   GET_AND_SUBSCRIBE,
   GET_DATASETS,
-  PAUSE,
   PUBLISH,
-  RESUME,
   SEARCH,
   SEARCH_SUBSCRIBE,
   SEARCH_TYPE_ANY,
@@ -33,13 +31,7 @@ export type StreamCommand =
 /** @deprecated: Use `StreamCommand`. */
 export type StreamCommands = StreamCommand;
 
-export type WsCommand =
-  | GetCommand
-  | StreamCommand
-  | typeof CLOSE
-  | typeof PAUSE
-  | typeof PUBLISH
-  | typeof RESUME;
+export type WsCommand = GetCommand | StreamCommand | typeof CLOSE | typeof PUBLISH;
 
 export type DatasetType = typeof APP_DATASET_TYPE | typeof DEVICE_DATASET_TYPE;
 
@@ -142,18 +134,4 @@ export interface CloseParams {
   [token: string]: boolean;
 }
 
-export interface PauseParams {
-  pauseStreams: boolean;
-}
-
-export interface ResumeParams {
-  token: string;
-}
-
-export type CloudVisionParams =
-  | AppParams
-  | CloseParams
-  | PauseParams
-  | QueryParams
-  | ResumeParams
-  | SearchParams;
+export type CloudVisionParams = AppParams | CloseParams | QueryParams | SearchParams;


### PR DESCRIPTION
Make tokens unique by using UUID, which also mean removing the deduping
logic performed on calls. This should now be handled by the client.

Also remove the unused pause/resume logic.