### PR TITLE
chore(connector): export constants from connector for use in middleware

### DIFF
--- a/packages/cloudvision-connector/src/index.ts
+++ b/packages/cloudvision-connector/src/index.ts
@@ -32,5 +32,14 @@ export {
 
 export { default } from './Connector';
 export { default as Parser } from './Parser';
-export { ACTIVE_CODE, CONNECTED, DISCONNECTED, EOF_CODE } from './constants';
+export {
+  ACTIVE_CODE,
+  CLOSE,
+  CONNECTED,
+  DISCONNECTED,
+  EOF_CODE,
+  PUBLISH,
+  SERVICE_REQUEST,
+  SUBSCRIBE,
+} from './constants';
 export { fromBinaryKey, hashObject, toBinaryKey, sanitizeOptions } from './utils';


### PR DESCRIPTION
Export CLOSE, PUBLISH, SERVICE_REQUEST, and SUBSCRIBE constants from
the connector to use in the worker middleware.