### PR TITLE
fix(cloudvision-connector): update type of DatasetObject

### DIFF
--- a/packages/cloudvision-connector/types/params.ts
+++ b/packages/cloudvision-connector/types/params.ts
@@ -58,6 +58,10 @@ export interface SearchOptions {
 export interface DatasetObject {
   name: string;
   type: DatasetType;
+  parent?: {
+    name: string;
+    type: string;
+  };
 }
 
 export interface QueryObject {


### PR DESCRIPTION
Update the type of DatasetObject to reflect the inclusion of `parent` as an optional field.