### PR TITLE
fix(cloudvision-connector): fix DatasetObject type

### DIFF
--- a/packages/cloudvision-connector/src/constants.ts
+++ b/packages/cloudvision-connector/src/constants.ts
@@ -15,7 +15,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { DatasetType, RequestContext, SearchType } from '../types';
+import { RequestContext, SearchType } from '../types';
 
 export const ERROR = 'ERROR';
 export const INFO = 'INFO';
@@ -54,7 +54,7 @@ export const SERVICE_REQUEST = 'serviceRequest';
 export const APP_DATASET_TYPE = 'app';
 export const CONFIG_DATASET_TYPE = 'config';
 export const DEVICE_DATASET_TYPE = 'device';
-export const ALL_DATASET_TYPES: DatasetType[] = [
+export const ALL_DATASET_TYPES: string[] = [
   APP_DATASET_TYPE,
   CONFIG_DATASET_TYPE,
   DEVICE_DATASET_TYPE,

--- a/packages/cloudvision-connector/types/params.ts
+++ b/packages/cloudvision-connector/types/params.ts
@@ -34,14 +34,6 @@ export type StreamCommands = StreamCommand;
 
 export type WsCommand = GetCommand | StreamCommand | typeof CLOSE | typeof PUBLISH;
 
-export type DatasetType =
-  | typeof APP_DATASET_TYPE
-  | typeof CONFIG_DATASET_TYPE
-  | typeof DEVICE_DATASET_TYPE;
-
-/** @deprecated: Use `DatasetType`. */
-export type DatasetTypes = DatasetType;
-
 export type SearchType = typeof SEARCH_TYPE_ANY | typeof SEARCH_TYPE_IP | typeof SEARCH_TYPE_MAC;
 
 export interface PathObject {
@@ -57,11 +49,8 @@ export interface SearchOptions {
 
 export interface DatasetObject {
   name: string;
-  type: DatasetType;
-  parent?: {
-    name: string;
-    type: string;
-  };
+  type: string;
+  parent?: DatasetObject;
 }
 
 export interface QueryObject {
@@ -123,7 +112,7 @@ export interface QueryParams {
 }
 
 export interface DatasetParams {
-  types?: DatasetType[];
+  types?: string[];
 }
 
 export interface SearchParams {

--- a/packages/cloudvision-connector/types/params.ts
+++ b/packages/cloudvision-connector/types/params.ts
@@ -1,10 +1,7 @@
 import { NeatType, PathElements } from 'a-msgpack';
 
 import {
-  APP_DATASET_TYPE,
   CLOSE,
-  CONFIG_DATASET_TYPE,
-  DEVICE_DATASET_TYPE,
   GET,
   GET_AND_SUBSCRIBE,
   GET_DATASETS,

--- a/packages/cloudvision-connector/types/params.ts
+++ b/packages/cloudvision-connector/types/params.ts
@@ -47,6 +47,7 @@ export interface SearchOptions {
 export interface DatasetObject {
   name: string;
   type: string;
+
   parent?: DatasetObject;
 }
 


### PR DESCRIPTION
- DatasetObject has been introduced with a recursive parent field on the backend. So, adjusting our types for it. 
- The decision has been made to loosen up restrictions on our `type` field and allow that to be a string.