### PR TITLE
Nanosecond support

### DIFF
--- a/packages/cloudvision-connector/src/Wrpc.ts
+++ b/packages/cloudvision-connector/src/Wrpc.ts
@@ -63,6 +63,7 @@ import { createCloseParams, toBinaryKey, validateResponse } from './utils';
 interface ConnectorOptions {
   batchResults: boolean;
   debugMode: boolean;
+  nanosecondMode: boolean;
   instrumentationConfig?: InstrumentationConfig;
 }
 
@@ -95,6 +96,7 @@ export default class Wrpc {
     options: ConnectorOptions = {
       batchResults: true,
       debugMode: false,
+      nanosecondMode: false,
     },
     websocketClass = WebSocket,
     parser = Parser,
@@ -330,7 +332,11 @@ export default class Wrpc {
 
       let msg: CloudVisionMessage;
       try {
-        msg = this.Parser.parse(event.data, this.connectorOptions.batchResults);
+        msg = this.Parser.parse(
+          event.data,
+          this.connectorOptions.batchResults,
+          this.connectorOptions.nanosecondMode,
+        );
         if (this.connectorOptions.debugMode) {
           // Used for debugging
           self.postMessage(

--- a/packages/cloudvision-connector/test/Parser.spec.ts
+++ b/packages/cloudvision-connector/test/Parser.spec.ts
@@ -32,6 +32,11 @@ import {
   expectedSecondNotif,
   expectedSixthNotif,
   expectedThirdNotif,
+  expectedFirstNotifNano,
+  expectedFourthNotifNano,
+  expectedSecondNotifNano,
+  expectedSixthNotifNano,
+  expectedThirdNotifNano,
   fifthNotif,
   firstNotif,
   firstNotifPublishRaw,
@@ -107,6 +112,18 @@ describe('Parser', () => {
         expectedSixthNotif,
       ],
     };
+
+    const nanoResult: CloudVisionNotifs = {
+      dataset: { type: DEVICE_DATASET_TYPE, name: 'Dodgers' },
+      metadata: {},
+      notifications: [
+        expectedThirdNotifNano,
+        expectedFirstNotifNano,
+        expectedSecondNotifNano,
+        expectedFourthNotifNano,
+        expectedSixthNotifNano,
+      ],
+    };
     const data = {
       result: encodedData,
       status: {},
@@ -122,17 +139,26 @@ describe('Parser', () => {
       status: {},
       token: 'someToken',
     };
+    const expectedNanosecondFormat = {
+      result: nanoResult,
+      status: {},
+      token: 'someToken',
+    };
 
     test('decode messages in batch format', () => {
-      expect(Parser.parse(JSON.stringify(data), true)).toEqual(expectedBatchData);
+      expect(Parser.parse(JSON.stringify(data), true, false)).toEqual(expectedBatchData);
     });
 
     test('decode messages in raw format', () => {
-      expect(Parser.parse(JSON.stringify(data), false)).toEqual(expectedRawFormat);
+      expect(Parser.parse(JSON.stringify(data), false, false)).toEqual(expectedRawFormat);
+    });
+
+    test('decode messages in nanosecond format', () => {
+      expect(Parser.parse(JSON.stringify(data), false, true)).toEqual(expectedNanosecondFormat);
     });
 
     test('decode empty result', () => {
-      expect(Parser.parse(JSON.stringify({}), false)).toEqual({
+      expect(Parser.parse(JSON.stringify({}), false, false)).toEqual({
         result: undefined,
         status: undefined,
         token: undefined,
@@ -250,7 +276,7 @@ describe('decodeNotifications', () => {
       },
     };
 
-    const decodedNotif = decodeNotifications(notif, true);
+    const decodedNotif = decodeNotifications(notif, true, false);
 
     expect(decodedNotif).toEqual(expectedNotif);
     expect(decodedNotif).not.toBe(expectedNotif);
@@ -269,7 +295,7 @@ describe('decodeNotifications', () => {
       },
     };
 
-    const batchedNotif = decodeNotifications(notif, true);
+    const batchedNotif = decodeNotifications(notif, true, false);
 
     expect(batchedNotif).toEqual(expectedNotif);
     expect(batchedNotif).not.toBe(expectedNotif);
@@ -288,7 +314,7 @@ describe('decodeNotifications', () => {
       },
     };
 
-    const batchedNotif = decodeNotifications(notif, true);
+    const batchedNotif = decodeNotifications(notif, true, false);
 
     expect(batchedNotif).toEqual(expectedNotif);
     expect(batchedNotif).not.toBe(expectedNotif);
@@ -308,7 +334,7 @@ describe('decodeNotifications', () => {
       },
     };
 
-    const batchedNotif = decodeNotifications(notif, true);
+    const batchedNotif = decodeNotifications(notif, true, false);
 
     expect(batchedNotif).toEqual(expectedNotif);
     expect(batchedNotif).not.toBe(expectedNotif);
@@ -330,7 +356,7 @@ describe('decodeNotifications', () => {
       ],
     };
 
-    const decodedNotif = decodeNotifications(notif, false);
+    const decodedNotif = decodeNotifications(notif, false, false);
 
     expect(decodedNotif).toEqual(expectedNotif);
     expect(decodedNotif).not.toBe(expectedNotif);
@@ -347,7 +373,7 @@ describe('decodeNotifications', () => {
       notifications: [expectedThirdNotif, expectedFirstNotif],
     };
 
-    const batchedNotif = decodeNotifications(notif, false);
+    const batchedNotif = decodeNotifications(notif, false, false);
 
     expect(batchedNotif).toEqual(expectedNotif);
     expect(batchedNotif).not.toBe(expectedNotif);
@@ -365,7 +391,7 @@ describe('decodeNotifications', () => {
       notifications: [expectedThirdNotif, expectedFirstNotif],
     };
 
-    const batchedNotif = decodeNotifications(notif, false);
+    const batchedNotif = decodeNotifications(notif, false, false);
 
     expect(batchedNotif).toEqual(expectedNotif);
     expect(batchedNotif).not.toBe(expectedNotif);
@@ -384,7 +410,7 @@ describe('decodeNotifications', () => {
       },
     };
 
-    const decodedNotif = decodeNotifications(notif, true);
+    const decodedNotif = decodeNotifications(notif, true, false);
 
     expect(decodedNotif).toEqual(expectedNotif);
     expect(decodedNotif).not.toBe(expectedNotif);
@@ -406,7 +432,7 @@ describe('decodeNotifications', () => {
       ],
     };
 
-    const batchedNotif = decodeNotifications(notif, false);
+    const batchedNotif = decodeNotifications(notif, false, false);
 
     expect(batchedNotif).toEqual(expectedNotif);
     expect(batchedNotif).not.toBe(expectedNotif);

--- a/packages/cloudvision-connector/test/Wrpc.spec.ts
+++ b/packages/cloudvision-connector/test/Wrpc.spec.ts
@@ -589,6 +589,7 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
     wrpc = new Wrpc({
       batchResults: true,
       debugMode: true,
+      nanosecondMode: false,
     });
     // @ts-expect-error Easier than to type everything
     commandFn = wrpc[fn];

--- a/packages/cloudvision-connector/test/fixtures.ts
+++ b/packages/cloudvision-connector/test/fixtures.ts
@@ -1,4 +1,5 @@
 import { PathElements } from 'a-msgpack';
+import JSBI from 'jsbi';
 
 import { DEVICE_DATASET_TYPE } from '../src/constants';
 import { ConvertedNotification, PublishNotification, Query, RawNotification } from '../types';
@@ -64,7 +65,7 @@ export const thirdNotif: RawNotification = {
 };
 export const fourthNotif: RawNotification = {
   path_elements: encodedPath1,
-  timestamp: { seconds: 1539822631, nanos: 9934968754 },
+  timestamp: { seconds: 1539822631, nanos: 993496875 },
   deletes: ['xA1CYXNlYmFsbCBUZWFt'],
 };
 export const fifthNotif: RawNotification = {
@@ -161,6 +162,70 @@ export const expectedSixthNotif: ConvertedNotification = {
   timestamp: 1539832611883,
   deletes: {},
 };
+export const expectedFirstNotifNano: ConvertedNotification = {
+  path_elements: path1,
+  timestamp: JSBI.BigInt('1539822611883496678'),
+  updates: {
+    xA1CYXNlYmFsbCBUZWFt: {
+      key: 'Baseball Team',
+      value: 'Dodgers',
+    },
+    xA1CYXkgQXJlYSBUZWFt: {
+      key: 'Bay Area Team',
+      value: 'Athletics',
+    },
+  },
+};
+export const expectedSecondNotifNano: ConvertedNotification = {
+  path_elements: path2,
+  timestamp: JSBI.BigInt('1539822631000883496'),
+  updates: {
+    xApCYXNrZXRiYWxs: {
+      key: 'Basketball',
+      value: 'NBA',
+    },
+  },
+};
+export const expectedThirdNotifNano: ConvertedNotification = {
+  path_elements: path1,
+  timestamp: JSBI.BigInt('1539822611000000000'),
+  updates: {
+    gcQFc3BvcnTECGJhc2ViYWxs: {
+      key: { sport: 'baseball' },
+      value: ['NL', 'AL'],
+    },
+  },
+  deletes: {
+    xA1CYXkgQXJlYSBUZWFt: {
+      key: 'Bay Area Team',
+    },
+  },
+};
+export const expectedFourthNotifNano: ConvertedNotification = {
+  path_elements: path1,
+  timestamp: JSBI.BigInt('1539822631993496875'),
+  deletes: {
+    xA1CYXNlYmFsbCBUZWFt: {
+      key: 'Baseball Team',
+    },
+  },
+};
+
+export const expectedFifthNotifNano: ConvertedNotification = {
+  path_elements: path3,
+  timestamp: JSBI.BigInt('1539822631000993496'),
+  updates: {
+    xApCYXNrZXRiYWxs: {
+      key: 'Basketball',
+      value: 'NBA',
+    },
+  },
+};
+export const expectedSixthNotifNano: ConvertedNotification = {
+  path_elements: path1,
+  timestamp: JSBI.BigInt('1539832611883496678'),
+  deletes: {},
+};
 
 export const firstNotifPublishRaw: PublishNotification = {
   path_elements: path1,
@@ -199,7 +264,7 @@ export const thirdNotifPublishRaw: PublishNotification = {
 };
 export const fourthNotifPublishRaw: PublishNotification = {
   path_elements: path1,
-  timestamp: { seconds: 1539822631, nanos: 9934968754 },
+  timestamp: { seconds: 1539822631, nanos: 993496875 },
   deletes: ['Baseball Team'],
 };
 export const sixthNotifPublishRaw: PublishNotification = {

--- a/packages/cloudvision-connector/test/instrumentation.spec.ts
+++ b/packages/cloudvision-connector/test/instrumentation.spec.ts
@@ -110,6 +110,7 @@ describe.each<[WsCommand, WrpcMethod, boolean]>([
         info: infoSpy,
         end: endSpy,
       },
+      nanosecondMode: false,
     });
     // @ts-expect-error Easier than to type everything
     commandFn = wrpc[fn];
@@ -304,6 +305,7 @@ describe.each<[StreamCommand, 'stream']>([
         info: infoSpy,
         end: endSpy,
       },
+      nanosecondMode: false,
     });
     commandFn = wrpc[fn];
     wrpc.run('ws://localhost:8080');
@@ -480,6 +482,7 @@ describe.each<[WsCommand, 'stream' | 'get']>([
         info: infoSpy,
         end: endSpy,
       },
+      nanosecondMode: false,
     });
     // @ts-expect-error Easier than to type everything
     commandFn = wrpc[fn];

--- a/packages/cloudvision-connector/types/notifications.ts
+++ b/packages/cloudvision-connector/types/notifications.ts
@@ -1,4 +1,5 @@
 import { PathElements, Timestamp } from 'a-msgpack';
+import JSBI from 'jsbi';
 
 import { RequestContext } from './connection';
 import { DatasetObject } from './params';
@@ -48,7 +49,7 @@ export type CloudVisionDelete<K> = CloudVisionDeletes<K>;
 
 export type ConvertedNotification<K = unknown, V = unknown> = CloudVisionNotification<
   PathElements,
-  number,
+  number | JSBI,
   CloudVisionUpdates<K, V>,
   CloudVisionDeletes<K>
 >;


### PR DESCRIPTION
feat(cloudvision-connector): add nanosecond mode to connector
Add nanosecondMode to Wrpc through the connector options.
When enabled, the parser will convert notification timestamps to JSBI,
instead of truncating them to millisecond numbers.