### PR TITLE
fix(msgpack): encode stripped neat objects

### DIFF
--- a/packages/a-msgpack/src/Encoder.ts
+++ b/packages/a-msgpack/src/Encoder.ts
@@ -1,11 +1,18 @@
 import JSBI from 'jsbi';
 
-import { NeatType } from '../types/neat';
+import { BasicNeatType } from '../types/neat';
 
 import { ExtData } from './ExtData';
 import { ExtensionCodec, ExtensionCodecType } from './ExtensionCodec';
-import { Bool, Float32, Float64, Int, Str } from './neat/NeatTypes';
-import { isBaseNeatType, sortMapByKey } from './neat/utils';
+import {
+  isBasicNeatType,
+  isBool,
+  isFloat32,
+  isFloat64,
+  isInt,
+  isStr,
+  sortMapByKey,
+} from './neat/utils';
 import { isJsbi, isPlainObject } from './utils/data';
 import { setInt64, setUint64 } from './utils/int';
 import { ensureUint8Array } from './utils/typedArrays';
@@ -205,8 +212,8 @@ export class Encoder {
     } else if (object instanceof Map) {
       this.encodeMap(object, depth);
     } else if (typeof object === 'object') {
-      if (isBaseNeatType(object)) {
-        this.encodeNeatClass(object as NeatType);
+      if (isBasicNeatType(object)) {
+        this.encodeNeatClass(object);
       } else if (isPlainObject(object as object)) {
         // Find out if it is a plain object
         this.encodePlainObject(object as Record<string, unknown>, depth);
@@ -222,16 +229,16 @@ export class Encoder {
     }
   }
 
-  encodeNeatClass(value: NeatType): void {
-    if (value instanceof Float32) {
+  encodeNeatClass(value: BasicNeatType): void {
+    if (isFloat32(value)) {
       // float 32 -- 0xca
       this.writeU8(0xca);
       this.writeF32(value.value);
-    } else if (value instanceof Float64) {
+    } else if (isFloat64(value)) {
       // float 64 -- 0xcb
       this.writeU8(0xcb);
       this.writeF64(value.value);
-    } else if (value instanceof Int) {
+    } else if (isInt(value)) {
       // int
       if (typeof value.value === 'bigint') {
         this.encodeBigInt(value.value);
@@ -240,10 +247,10 @@ export class Encoder {
       } else {
         this.encodeNumber(value.value as number);
       }
-    } else if (value instanceof Str) {
+    } else if (isStr(value)) {
       // string
       this.encodeString(value.value);
-    } else if (value instanceof Bool) {
+    } else if (isBool(value)) {
       // bool
       this.encodeBoolean(value.value);
     } else {

--- a/packages/a-msgpack/src/neat/utils.ts
+++ b/packages/a-msgpack/src/neat/utils.ts
@@ -1,16 +1,11 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import { PathElements } from '../../types/neat';
+import { BasicNeatType, PathElements } from '../../types/neat';
 
 import { Bool, Float32, Float64, Int, Nil, Pointer, Str } from './NeatTypes';
 
 interface SerializedNeatType {
   __neatTypeClass: string;
-  value: unknown;
-}
-
-interface BasicNeatType {
-  type: Bool['type'] | Float32['type'] | Float64['type'] | Int['type'] | Nil['type'] | Str['type'];
   value: unknown;
 }
 
@@ -20,7 +15,27 @@ interface PointerNeatType {
   delimiter: string;
 }
 
-export function isBaseNeatType(value: unknown): boolean {
+export function isFloat32(value: BasicNeatType): value is Float32 {
+  return value.type === 'float32';
+}
+
+export function isFloat64(value: BasicNeatType): value is Float64 {
+  return value.type === 'float64';
+}
+
+export function isInt(value: BasicNeatType): value is Int {
+  return value.type === 'int';
+}
+
+export function isStr(value: BasicNeatType): value is Str {
+  return value.type === 'str';
+}
+
+export function isBool(value: BasicNeatType): value is Bool {
+  return value.type === 'bool';
+}
+
+export function isBasicNeatType(value: unknown): value is BasicNeatType {
   if (typeof value === 'object' && value !== null) {
     if (Object.keys(value).length === 2 && 'type' in value && 'value' in value) {
       const neatValue = value as BasicNeatType;
@@ -34,7 +49,7 @@ export function isBaseNeatType(value: unknown): boolean {
 
 export function isNeatType(value: unknown): boolean {
   if (typeof value === 'object' && value !== null) {
-    if (isBaseNeatType(value)) {
+    if (isBasicNeatType(value)) {
       return true;
     }
     if (

--- a/packages/a-msgpack/types/neat.ts
+++ b/packages/a-msgpack/types/neat.ts
@@ -16,6 +16,11 @@ export interface Timestamp {
 export type BaseType = Bool | Float32 | Float64 | Int | Nil | Pointer | Str | Map<unknown, unknown>;
 export type NeatType = BaseType | Element;
 
+export interface BasicNeatType {
+  type: Bool['type'] | Float32['type'] | Float64['type'] | Int['type'] | Nil['type'] | Str['type'];
+  value: unknown;
+}
+
 export type NeatTypeClass =
   | typeof Bool
   | typeof Float32


### PR DESCRIPTION
The encodeNeatClass function assumes that it receives an instantiated
Neat class (using instanceOf), but while it is always passed an object
that satisfies the constraints of a neat object, it may be passed a
neat object that has been stripped of its custom class (in this case,
passed across a worker socket).
Create utils to test BasicNeatTypes for their type based on `type`
property.
Rename isBaseNeatType util to isBasicNeatType.