### PR TITLE
chore(docs): update typedoc-plugin-markdown and mock-socket

### DIFF
--- a/packages/a-msgpack/package-lock.json
+++ b/packages/a-msgpack/package-lock.json
@@ -4852,9 +4852,9 @@
 			}
 		},
 		"typedoc-plugin-markdown": {
-			"version": "3.11.5",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.5.tgz",
-			"integrity": "sha512-eofjcalj8FObwVqiH8EPwurxUBKYwfJDOlx2zF3Iege1mGgy0KdBquVikglKvnXuB1d60b5K8BRqkYsquiGReQ==",
+			"version": "3.11.6",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.6.tgz",
+			"integrity": "sha512-CV1BuxL7HR/EE1ctnPXOWzf4/Exl0FzkwtFVYaKTVWTnD/dkFLgABOfWuOL4lPmzLUOsAL85pmq+/PB6cdRppw==",
 			"dev": true,
 			"requires": {
 				"handlebars": "^4.7.7"

--- a/packages/a-msgpack/package.json
+++ b/packages/a-msgpack/package.json
@@ -85,7 +85,7 @@
     "ts-jest": "27.0.7",
     "tslib": "2.3.1",
     "typedoc": "0.22.9",
-    "typedoc-plugin-markdown": "3.11.5",
+    "typedoc-plugin-markdown": "3.11.6",
     "typescript": "4.4.4"
   }
 }

--- a/packages/cloudvision-connector/package-lock.json
+++ b/packages/cloudvision-connector/package-lock.json
@@ -3838,9 +3838,9 @@
 			"dev": true
 		},
 		"mock-socket": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.0.7.tgz",
-			"integrity": "sha512-jWHRwwS6ZwvYkXhl/xSGlrvoBZfz21cKRuQ2WL3A9FdVOR/f21nV9b1W8tiVCsYo3HS4oCIB5yZTIqycBp9D+g==",
+			"version": "9.0.8",
+			"resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.0.8.tgz",
+			"integrity": "sha512-8Syqkaaa2SzRqW68DEsnZkKQicHP7hVzfj3uCvigB5TL79H1ljKbwmOcRIENkx0ZTyu/5W6u+Pk9Qy6JCp38Ww==",
 			"dev": true
 		},
 		"ms": {
@@ -4880,9 +4880,9 @@
 			}
 		},
 		"typedoc-plugin-markdown": {
-			"version": "3.11.5",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.5.tgz",
-			"integrity": "sha512-eofjcalj8FObwVqiH8EPwurxUBKYwfJDOlx2zF3Iege1mGgy0KdBquVikglKvnXuB1d60b5K8BRqkYsquiGReQ==",
+			"version": "3.11.6",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.6.tgz",
+			"integrity": "sha512-CV1BuxL7HR/EE1ctnPXOWzf4/Exl0FzkwtFVYaKTVWTnD/dkFLgABOfWuOL4lPmzLUOsAL85pmq+/PB6cdRppw==",
 			"dev": true,
 			"requires": {
 				"handlebars": "^4.7.7"

--- a/packages/cloudvision-connector/package.json
+++ b/packages/cloudvision-connector/package.json
@@ -83,7 +83,7 @@
     "jest": "27.3.1",
     "jest-environment-jsdom": "27.3.1",
     "js-yaml": "4.1.0",
-    "mock-socket": "9.0.7",
+    "mock-socket": "9.0.8",
     "prettier": "2.4.1",
     "rimraf": "3.0.2",
     "rollup": "2.60.0",
@@ -91,7 +91,7 @@
     "ts-jest": "27.0.7",
     "tslib": "2.3.1",
     "typedoc": "0.22.9",
-    "typedoc-plugin-markdown": "3.11.5",
+    "typedoc-plugin-markdown": "3.11.6",
     "typescript": "4.4.4"
   }
 }

--- a/packages/cloudvision-connector/test/websocket-setup.ts
+++ b/packages/cloudvision-connector/test/websocket-setup.ts
@@ -18,7 +18,6 @@ class TextDE {
   }
 }
 
-// @ts-expect-error url field of constructor needs URL type
 global.WebSocket = WebSocket;
 
 global.TextDecoder = TextDE;

--- a/packages/cloudvision-grpc-web/package-lock.json
+++ b/packages/cloudvision-grpc-web/package-lock.json
@@ -5308,9 +5308,9 @@
 			}
 		},
 		"typedoc-plugin-markdown": {
-			"version": "3.11.5",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.5.tgz",
-			"integrity": "sha512-eofjcalj8FObwVqiH8EPwurxUBKYwfJDOlx2zF3Iege1mGgy0KdBquVikglKvnXuB1d60b5K8BRqkYsquiGReQ==",
+			"version": "3.11.6",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.6.tgz",
+			"integrity": "sha512-CV1BuxL7HR/EE1ctnPXOWzf4/Exl0FzkwtFVYaKTVWTnD/dkFLgABOfWuOL4lPmzLUOsAL85pmq+/PB6cdRppw==",
 			"dev": true,
 			"requires": {
 				"handlebars": "^4.7.7"

--- a/packages/cloudvision-grpc-web/package.json
+++ b/packages/cloudvision-grpc-web/package.json
@@ -92,7 +92,7 @@
     "tsc-alias": "1.3.10",
     "tslib": "2.3.1",
     "typedoc": "0.22.9",
-    "typedoc-plugin-markdown": "3.11.5",
+    "typedoc-plugin-markdown": "3.11.6",
     "typescript": "4.4.4"
   }
 }


### PR DESCRIPTION
- Update typedoc-plugin-markdown to 3.11.6
- Update mock-socket to 9.0.8
- remove ts-expect-error from websocket type