### PR TITLE
feat(cloudvision-grpc-web): Add support to close requests on unsubscribe

### DIFF
--- a/packages/cloudvision-grpc-web/src/grpc/index.ts
+++ b/packages/cloudvision-grpc-web/src/grpc/index.ts
@@ -1,6 +1,6 @@
 import { grpc } from '@improbable-eng/grpc-web';
 import { ControlFunctions, GrpcControlMessage, GrpcSource, RpcOptions } from '@types';
-import { Subject } from 'rxjs';
+import { finalize, share, Subject } from 'rxjs';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const DEFAULT_CONTROL_FUNCTIONS: ControlFunctions<any> = {
@@ -57,10 +57,10 @@ export function fromGrpcInvoke<Req extends grpc.ProtobufMessage, Res extends grp
     },
   };
 
-  grpc.invoke(methodDescriptor, rpcOptions);
+  const request = grpc.invoke(methodDescriptor, rpcOptions);
 
   return {
-    data: dataSubject.asObservable(),
+    data: dataSubject.pipe(finalize(request.close), share()),
     messages: controlMessageSubject.asObservable(),
   };
 }


### PR DESCRIPTION
This commit adds the support to auto-close stream requests when there is no listener.

It does this by wrapping the subject with a custom observable that is initialized with the close handler returned by grpc.invoke. It then keeps track of the listeners as they subscribe to (or unsubscribe from) this wrapper. When the listeners drop to zero, it triggers the close handler.