### PR TITLE
fix(cloudvision-grpc-web): Add a try/catch around request close

### DIFF
--- a/packages/cloudvision-grpc-web/src/grpc/index.ts
+++ b/packages/cloudvision-grpc-web/src/grpc/index.ts
@@ -60,7 +60,16 @@ export function fromGrpcInvoke<Req extends grpc.ProtobufMessage, Res extends grp
   const request = grpc.invoke(methodDescriptor, rpcOptions);
 
   return {
-    data: dataSubject.pipe(finalize(request.close), share()),
+    data: dataSubject.pipe(
+      finalize(() => {
+        try {
+          request.close();
+        } catch (e) {
+          // Do nothing ATM
+        }
+      }),
+      share(),
+    ),
     messages: controlMessageSubject.asObservable(),
   };
 }


### PR DESCRIPTION
The request may already be closed, in which case the close handler throws an error. We want to catch and suppress that error.