### PR TITLE
fix(a-msgpack): write uint32 when appropriate

### DIFF
--- a/packages/a-msgpack/src/Encoder.ts
+++ b/packages/a-msgpack/src/Encoder.ts
@@ -271,6 +271,9 @@ export class Encoder {
     } else if (value < 0) {
       this.writeU8(0xd3);
       this.writeI64(value);
+    } else if (value < 0x100000000) {
+      this.writeU8(0xce);
+      this.writeU32(Number(value))
     } else {
       this.writeU8(0xcf);
       this.writeU64(value);
@@ -288,6 +291,9 @@ export class Encoder {
     } else if (strValue < '0') {
       this.writeU8(0xd3);
       this.writeI64(strValue);
+    } else if (JSBI.LE(value, 0xffffffff)) {
+      this.writeU8(0xce);
+      this.writeU32(JSBI.toNumber(value));
     } else {
       this.writeU8(0xcf);
       this.writeU64(strValue);

--- a/packages/a-msgpack/test/codec_tests.yaml
+++ b/packages/a-msgpack/test/codec_tests.yaml
@@ -69,6 +69,9 @@ tests:
   - name: min int32 as int64
     i64: '-2147483648'
     out: [210, 128, 0, 0, 0]
+  - name: max uint32 as int64
+    i64: '4294967295'
+    out: [206, 255, 255, 255, 255]
   - name: zero int64
     i64: '0'
     out: [0]
@@ -91,10 +94,10 @@ tests:
     i16: 42
     out: [42]
   - name: int32 42
-    i8: 42
+    i32: 42
     out: [42]
   - name: int64 42
-    i8: 42
+    i64: 42
     out: [42]
   - name: max int16 as int32
     i32: 32767


### PR DESCRIPTION
Add case for JSBI values between int32.MAXSAFE and uint32.MAXSAFE to write those values as uint32 instead of uint64.