### PR TITLE
fix(rollup): add process.env to rollup

### DIFF
--- a/packages/a-msgpack/package.json
+++ b/packages/a-msgpack/package.json
@@ -63,6 +63,7 @@
     "@arista/prettier-config": "1.1.4",
     "@rollup/plugin-commonjs": "22.0.2",
     "@rollup/plugin-node-resolve": "13.3.0",
+    "@rollup/plugin-replace": "4.0.0",
     "@rollup/plugin-typescript": "8.5.0",
     "@types/base64-js": "1.3.0",
     "@types/jest": "27.5.2",

--- a/packages/a-msgpack/rollup.config.js
+++ b/packages/a-msgpack/rollup.config.js
@@ -1,5 +1,6 @@
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
+import replace from '@rollup/plugin-replace';
 import typescript from '@rollup/plugin-typescript';
 import { terser } from 'rollup-plugin-terser';
 
@@ -43,6 +44,17 @@ if (env === 'development' || env === 'production') {
     globals,
     name: 'a-msgpack',
   };
+  config.plugins.push(
+    replace({
+      preventAssignment: true,
+      values: {
+        'process.env.NODE_ENV': JSON.stringify(env),
+        'process.env.TEXT_ENCODING': JSON.stringify('always'),
+        'process.env.TEXT_DECODER': JSON.stringify('always'),
+      },
+    }),
+    commonjs(),
+  );
 }
 
 if (env === 'production') {


### PR DESCRIPTION
Packages using a-msgpack that don't define process.env encounter an error because utf8.ts uses process.env.TEXT_ENCODING to determine the usage of the TextEncoding API.
Add this process.env in the rollup config.